### PR TITLE
refactor: convert transform and translate_img to Image methods

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -59,7 +59,7 @@ test "basic_shapes" (it : @test.Test) {
 
   // Apply transformations and effects
   let semi_transparent = @vg.with_opacity(red_circle, 0.7)
-  let translated_ellipse = @vg.translate_img(50.0, 0.0, blue_ellipse)
+  let translated_ellipse = blue_ellipse.translate_img(50.0, 0.0)
 
   // Compose images
   let _composed = @vg.compose_imgs(semi_transparent, translated_ellipse)
@@ -141,7 +141,7 @@ test "transformations examples" {
   let rect_img = @vg.rectangle(@vg.blue(), 50.0, 30.0)
 
   // Translate an image
-  let moved = @vg.translate_img(10.0, 20.0, circle_img)
+  let moved = circle_img.translate_img(10.0, 20.0)
 
   // Scale an image
   let scaled = @vg.scale_image(2.0, 1.5, rect_img)

--- a/hello.mbt
+++ b/hello.mbt
@@ -5,6 +5,6 @@
 pub fn example() -> Image {
   let red_circle = circle(red(), 30.0)
   let blue_rect = rectangle(blue(), 40.0, 40.0)
-  let translated_rect = translate_img(50.0, 0.0, blue_rect)
+  let translated_rect = blue_rect.translate_img(50.0, 0.0)
   compose_imgs(red_circle, translated_rect)
 }

--- a/hello_test.mbt
+++ b/hello_test.mbt
@@ -33,11 +33,9 @@ test "complete workflow - create and render image" {
   // Create a complex image
   let background = @vg.rectangle(@vg.gray(0.9), 200.0, 200.0)
   let red_circle = @vg.circle(@vg.red(), 40.0)
-  let blue_circle = @vg.translate_img(60.0, 0.0, @vg.circle(@vg.blue(), 30.0))
-  let green_rect = @vg.translate_img(
-    -50.0,
-    50.0,
-    @vg.rectangle(@vg.green(), 30.0, 20.0),
+  let blue_circle = @vg.circle(@vg.blue(), 30.0).translate_img(60.0, 0.0)
+  let green_rect = @vg.rectangle(@vg.green(), 30.0, 20.0).translate_img(
+    -50.0, 50.0,
   )
   let complex_image = background
     |> @vg.compose_imgs(red_circle)
@@ -112,7 +110,7 @@ test "transformation chain" {
   // Apply multiple transformations
   let scaled = @vg.scale_image(2.0, 1.5, original)
   let rotated = @vg.rotate_image(3.14159 / 4.0, scaled) // 45 degrees
-  let transformed = @vg.translate_img(20.0, 10.0, rotated)
+  let transformed = rotated.translate_img(20.0, 10.0)
 
   // Test that transformations work
   let origin_color = transformed(@vg.point(0.0, 0.0))

--- a/image.mbt
+++ b/image.mbt
@@ -74,7 +74,7 @@ pub fn line(
 
 ///|
 /// Transform an image
-pub fn transform(t : Transform, img : Image) -> Image {
+pub fn Image::transform(img : Image, t : Transform) -> Image {
   p => match invert(t) {
     Some(inv_t) => img(apply(inv_t, p))
     None => transparent()
@@ -83,20 +83,20 @@ pub fn transform(t : Transform, img : Image) -> Image {
 
 ///|
 /// Translate an image
-pub fn translate_img(dx : Double, dy : Double, img : Image) -> Image {
-  transform(make_translate(dx, dy), img)
+pub fn Image::translate_img(img : Image, dx : Double, dy : Double) -> Image {
+  img.transform(make_translate(dx, dy))
 }
 
 ///|
 /// Scale an image
 pub fn scale_image(sx : Double, sy : Double, img : Image) -> Image {
-  transform(make_scale(sx, sy), img)
+  img.transform(make_scale(sx, sy))
 }
 
 ///|
 /// Rotate an image
 pub fn rotate_image(angle : Double, img : Image) -> Image {
-  transform(make_rotate(angle), img)
+  img.transform(make_rotate(angle))
 }
 
 ///|

--- a/image_test.mbt
+++ b/image_test.mbt
@@ -65,7 +65,7 @@ test "rectangle image" {
 ///|
 test "image translation" {
   let circle_img = @vg.circle(@vg.red(), 3.0)
-  let translated = @vg.translate_img(5.0, 0.0, circle_img)
+  let translated = circle_img.translate_img(5.0, 0.0)
   let original_center = @vg.point(0.0, 0.0)
   let new_center = @vg.point(5.0, 0.0)
   let c_original = translated(original_center)
@@ -92,7 +92,7 @@ test "image scaling" {
 ///|
 test "image composition" {
   let red_circle = @vg.circle(@vg.red(), 3.0)
-  let blue_circle = @vg.translate_img(2.0, 0.0, @vg.circle(@vg.blue(), 3.0))
+  let blue_circle = @vg.circle(@vg.blue(), 3.0).translate_img(2.0, 0.0)
   let composed = @vg.compose_imgs(red_circle, blue_circle)
   let red_only = @vg.point(-2.0, 0.0) // Only in red circle
   let blue_only = @vg.point(4.0, 0.0) // Only in blue circle
@@ -251,14 +251,12 @@ test "image rendering showcase" (it : @test.Test) {
   let blue_ellipse = @vg.ellipse(@vg.blue(), 30.0, 20.0)
   let green_rect = @vg.rectangle(@vg.green(), 40.0, 30.0)
   let composed = background
-    |> @vg.compose_imgs(@vg.translate_img(50.0, 40.0, red_circle))
-    |> @vg.compose_imgs(@vg.translate_img(100.0, 60.0, blue_ellipse))
-    |> @vg.compose_imgs(@vg.translate_img(150.0, 50.0, green_rect))
+    |> @vg.compose_imgs(red_circle.translate_img(50.0, 40.0))
+    |> @vg.compose_imgs(blue_ellipse.translate_img(100.0, 60.0))
+    |> @vg.compose_imgs(green_rect.translate_img(150.0, 50.0))
     |> @vg.compose_imgs(
-      @vg.translate_img(
-        75.0,
-        90.0,
-        @vg.with_opacity(@vg.circle(@vg.yellow(), 20.0), 0.7),
+      @vg.with_opacity(@vg.circle(@vg.yellow(), 20.0), 0.7).translate_img(
+        75.0, 90.0,
       ),
     )
   let svg_string = composed.render_image_to_svg(200.0, 150.0, 40)
@@ -327,17 +325,17 @@ test "transform showcase" (it : @test.Test) {
   let base_circle = @vg.circle(@vg.red(), 20.0)
 
   // Apply different transformations
-  let translated = @vg.translate_img(60.0, 0.0, base_circle)
+  let translated = base_circle.translate_img(60.0, 0.0)
   let scaled = @vg.scale_image(1.5, 0.8, base_circle)
   let rotated = @vg.rotate_image(3.14159 / 4.0, base_circle) // 45 degrees
 
   // Compose all transformations
   let background = @vg.rectangle(@vg.gray(0.9), 200.0, 100.0)
   let showcase = background
-    |> @vg.compose_imgs(@vg.translate_img(40.0, 50.0, base_circle))
-    |> @vg.compose_imgs(@vg.translate_img(100.0, 50.0, translated))
-    |> @vg.compose_imgs(@vg.translate_img(40.0, 30.0, scaled))
-    |> @vg.compose_imgs(@vg.translate_img(140.0, 30.0, rotated))
+    |> @vg.compose_imgs(base_circle.translate_img(40.0, 50.0))
+    |> @vg.compose_imgs(translated.translate_img(100.0, 50.0))
+    |> @vg.compose_imgs(scaled.translate_img(40.0, 30.0))
+    |> @vg.compose_imgs(rotated.translate_img(140.0, 30.0))
   let svg_string = showcase.render_image_to_svg(200.0, 100.0, 30)
   it.write(svg_string)
   it.snapshot(filename="transform_showcase.svg")

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -152,10 +152,6 @@ fn tile_image(Image, Double, Double) -> Image
 
 fn to_hex(Color) -> String
 
-fn transform(Transform, Image) -> Image
-
-fn translate_img(Double, Double, Image) -> Image
-
 fn transparent() -> Color
 
 fn white() -> Color
@@ -204,6 +200,8 @@ pub(all) struct Image((Point) -> Color)
 #deprecated
 fn Image::inner(Self) -> (Point) -> Color
 fn Image::render_image_to_svg(Self, Double, Double, Int) -> String
+fn Image::transform(Self, Transform) -> Self
+fn Image::translate_img(Self, Double, Double) -> Self
 
 pub enum ImageOp {
   Const(Color)


### PR DESCRIPTION
- Change transform from standalone function to Image::transform method
- Change translate_img from standalone function to Image::translate_img method
- Update all call sites to use method syntax (img.translate_img(dx, dy))
- Improves API ergonomics with more fluent method chaining
- All 132 tests passing
