### PR TITLE
Enable unnecessary_annotation lint and drop redundant qualifiers

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -52,9 +52,9 @@ test "basic_shapes" (it : @test.Test) {
   let red_circle = @vg.Image::circle(@color.red(), 50.0)
   let blue_ellipse = @vg.Image::ellipse(@color.blue(), 60.0, 40.0)
   let _triangle = @vg.Image::polygon(@color.green(), [
-    @vg.Point::Point(0.0, -30.0),
-    @vg.Point::Point(-30.0, 30.0),
-    @vg.Point::Point(30.0, 30.0),
+    Point(0.0, -30.0),
+    Point(-30.0, 30.0),
+    Point(30.0, 30.0),
   ])
 
   // Apply transformations and effects
@@ -66,19 +66,15 @@ test "basic_shapes" (it : @test.Test) {
 
   // Create paths with object-oriented API
   let custom_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 10.0))
-    .line_to(@vg.Point::Point(90.0, 10.0))
-    .curve_to(
-      @vg.Point::Point(110.0, 10.0),
-      @vg.Point::Point(110.0, 30.0),
-      @vg.Point::Point(90.0, 30.0),
-    )
+    .move_to(Point(10.0, 10.0))
+    .line_to(Point(90.0, 10.0))
+    .curve_to(Point(110.0, 10.0), Point(110.0, 30.0), Point(90.0, 30.0))
     .close_path()
 
   // Create SVG output with advanced shapes
   let svg_doc = @svg.new_svg(200.0, 200.0)
-    .render_circle(@vg.Point::Point(100.0, 100.0), 50.0, @color.red())
-    .render_ellipse(@vg.Point::Point(150.0, 100.0), 30.0, 20.0, @color.blue())
+    .render_circle(Point(100.0, 100.0), 50.0, @color.red())
+    .render_ellipse(Point(150.0, 100.0), 30.0, 20.0, @color.blue())
     .render_path(custom_path, @color.green())
   it.write(svg_doc.to_string())
   it.snapshot(filename="basic_shapes.svg")
@@ -120,9 +116,9 @@ test "basic shapes examples" {
 
   // Create a polygon (triangle)
   let triangle = @vg.Image::polygon(@color.yellow(), [
-    @vg.Point::Point(0.0, -20.0),
-    @vg.Point::Point(-20.0, 20.0),
-    @vg.Point::Point(20.0, 20.0),
+    Point(0.0, -20.0),
+    Point(-20.0, 20.0),
+    Point(20.0, 20.0),
   ])
 
   // Use the variables to avoid unused warnings
@@ -173,15 +169,15 @@ test "colors and effects examples" {
   let gradient = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-50.0, 0.0),
-    @vg.Point::Point(50.0, 0.0),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
   )
 
   // Radial gradient
   let radial = @vg.Image::radial_gradient(
     @color.white(),
     @color.black(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     50.0,
   )
 
@@ -200,19 +196,15 @@ test "colors and effects examples" {
 test "paths examples" {
   // Create a custom path with method chaining
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 10.0))
-    .line_to(@vg.Point::Point(90.0, 10.0))
-    .curve_to(
-      @vg.Point::Point(110.0, 10.0),
-      @vg.Point::Point(110.0, 30.0),
-      @vg.Point::Point(90.0, 30.0),
-    )
+    .move_to(Point(10.0, 10.0))
+    .line_to(Point(90.0, 10.0))
+    .curve_to(Point(110.0, 10.0), Point(110.0, 30.0), Point(90.0, 30.0))
     .close_path()
 
   // Create predefined shapes
   let rectangle = @vg.Path::rect(0.0, 0.0, 50.0, 30.0)
-  let circle = @vg.Path::circle(@vg.Point::Point(25.0, 25.0), 20.0)
-  let ellipse = @vg.Path::ellipse(@vg.Point::Point(0.0, 0.0), 30.0, 15.0)
+  let circle = @vg.Path::circle(Point(25.0, 25.0), 20.0)
+  let ellipse = @vg.Path::ellipse(Point(0.0, 0.0), 30.0, 15.0)
 
   // Transform paths
   let transform = @geometry.make_translate(10.0, 20.0)
@@ -252,21 +244,16 @@ test "paths examples" {
 ///|
 test "canvas rendering examples" {
   let custom_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 10.0))
-    .line_to(@vg.Point::Point(50.0, 10.0))
+    .move_to(Point(10.0, 10.0))
+    .line_to(Point(50.0, 10.0))
     .close_path()
 
   // Create an HTML5 Canvas document with fluent method chaining
   let canvas_doc = @canvas.new_canvas(400.0, 300.0)
-    .render_circle(@vg.Point::Point(100.0, 100.0), 50.0, @color.red())
+    .render_circle(Point(100.0, 100.0), 50.0, @color.red())
     .render_rectangle(150.0, 50.0, 80.0, 60.0, @color.blue())
     .render_path(custom_path, @color.green())
-    .render_text(
-      "Hello Canvas!",
-      @vg.Point::Point(200.0, 200.0),
-      16.0,
-      @color.black(),
-    )
+    .render_text("Hello Canvas!", Point(200.0, 200.0), 16.0, @color.black())
 
   // Generate JavaScript code
   let js_code = canvas_doc.to_js()
@@ -285,22 +272,17 @@ test "canvas rendering examples" {
 ///|
 test "pdf generation examples" {
   let star_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(0.0, -20.0))
-    .line_to(@vg.Point::Point(5.0, -5.0))
-    .line_to(@vg.Point::Point(20.0, -5.0))
+    .move_to(Point(0.0, -20.0))
+    .line_to(Point(5.0, -5.0))
+    .line_to(Point(20.0, -5.0))
     .close_path()
 
   // Create a PDF document with fluent method chaining
   let pdf_doc = @pdf.PdfDocument::new(210.0, 297.0) // A4 size
-    .render_circle(@vg.Point::Point(105.0, 100.0), 30.0, @color.red())
+    .render_circle(Point(105.0, 100.0), 30.0, @color.red())
     .render_rectangle(50.0, 150.0, 110.0, 50.0, @color.blue())
     .render_path(star_path, @color.gold())
-    .render_text(
-      "PDF Graphics Demo",
-      @vg.Point::Point(50.0, 250.0),
-      14.0,
-      @color.black(),
-    )
+    .render_text("PDF Graphics Demo", Point(50.0, 250.0), 14.0, @color.black())
 
   // Generate PDF string
   let pdf_content = pdf_doc.to_string()
@@ -449,9 +431,9 @@ test "spirograph" (it : @test.Test) {
       let x = (x_raw * 1000000.0).round() / 1000000.0
       let y = (y_raw * 1000000.0).round() / 1000000.0
       if i == 0 {
-        path = path.move_to(@vg.Point::Point(x, y))
+        path = path.move_to(Point(x, y))
       } else {
-        path = path.line_to(@vg.Point::Point(x, y))
+        path = path.line_to(Point(x, y))
       }
     }
 
@@ -496,7 +478,7 @@ test "rainbow flower" (it : @test.Test) {
     let petal_cx = (petal_cx_raw * 1000000.0).round() / 1000000.0
     let petal_cy = (petal_cy_raw * 1000000.0).round() / 1000000.0
     doc = doc.render_ellipse(
-      @vg.Point::Point(petal_cx, petal_cy),
+      Point(petal_cx, petal_cy),
       50.0,
       25.0,
       @color.rgba(color.r, color.g, color.b, 0.7),
@@ -504,8 +486,8 @@ test "rainbow flower" (it : @test.Test) {
   }
 
   // Center circle
-  doc = doc.render_circle(@vg.Point::Point(cx, cy), 30.0, @color.gold())
-  doc = doc.render_circle(@vg.Point::Point(cx, cy), 20.0, @color.orange())
+  doc = doc.render_circle(Point(cx, cy), 30.0, @color.gold())
+  doc = doc.render_circle(Point(cx, cy), 20.0, @color.orange())
   it.write(doc.to_string())
   it.snapshot(filename="rainbow_flower.svg")
 }
@@ -542,11 +524,7 @@ test "sierpinski triangle" (it : @test.Test) {
   ) -> @svg.SvgDocument {
     if depth == 0 {
       doc.render_polygon(
-        [
-          @vg.Point::Point(x1, y1),
-          @vg.Point::Point(x2, y2),
-          @vg.Point::Point(x3, y3),
-        ],
+        [Point(x1, y1), Point(x2, y2), Point(x3, y3)],
         @color.hsv(depth.to_double() * 60.0, 0.7, 0.8),
       )
     } else {
@@ -609,7 +587,7 @@ test "concentric waves" (it : @test.Test) {
     let hue = i.to_double() / num_rings.to_double() * 360.0 * 2.0 // Two full color cycles
     let saturation = 0.7 + 0.3 * @math.sin(i.to_double() * 0.3)
     let color = @color.hsv(hue % 360.0, saturation, 0.9)
-    doc = doc.render_circle(@vg.Point::Point(cx, cy), radius, color)
+    doc = doc.render_circle(Point(cx, cy), radius, color)
   }
   it.write(doc.to_string())
   it.snapshot(filename="concentric_waves.svg")
@@ -650,19 +628,15 @@ test "starfield" (it : @test.Test) {
     // Star color varies from white to blue-ish
     let bright_b = if brightness + 0.2 > 1.0 { 1.0 } else { brightness + 0.2 }
     let color = @color.rgba(brightness, brightness, bright_b, brightness)
-    doc = doc.render_circle(@vg.Point::Point(x, y), size, color)
+    doc = doc.render_circle(Point(x, y), size, color)
   }
 
   // Add a few larger "bright" stars
   for i = 0; i < 10; i = i + 1 {
     let x = pseudo_random(i * 7 + 100) * width
     let y = pseudo_random(i * 7 + 101) * height
-    doc = doc.render_circle(@vg.Point::Point(x, y), 4.0, @color.white())
-    doc = doc.render_circle(
-      @vg.Point::Point(x, y),
-      8.0,
-      @color.rgba(1.0, 1.0, 1.0, 0.3),
-    )
+    doc = doc.render_circle(Point(x, y), 4.0, @color.white())
+    doc = doc.render_circle(Point(x, y), 8.0, @color.rgba(1.0, 1.0, 1.0, 0.3))
   }
   it.write(doc.to_string())
   it.snapshot(filename="starfield.svg")
@@ -703,7 +677,7 @@ test "op art pattern" (it : @test.Test) {
       let circle_size = cell_size * 0.4 * (1.0 + 0.5 * @math.sin(dist * 0.05))
       let circle_color = if checker { @color.white() } else { @color.black() }
       doc = doc.render_circle(
-        @vg.Point::Point(x + cell_size / 2.0, y + cell_size / 2.0),
+        Point(x + cell_size / 2.0, y + cell_size / 2.0),
         circle_size,
         circle_color,
       )
@@ -734,15 +708,15 @@ test "gradient gallery" (it : @test.Test) {
   let linear_grad = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-40.0, 0.0),
-    @vg.Point::Point(40.0, 0.0),
+    Point(-40.0, 0.0),
+    Point(40.0, 0.0),
   )
 
   // Radial gradient
   let radial_grad = @vg.Image::radial_gradient(
     @color.yellow(),
     @color.purple(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     50.0,
   )
 
@@ -750,26 +724,26 @@ test "gradient gallery" (it : @test.Test) {
   let conic_grad = @vg.Image::conic_gradient(
     @color.cyan(),
     @color.magenta(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     0.0,
   )
 
   // Render gradient samples as rectangles
   doc = doc.render_text(
     "Linear Gradient",
-    @vg.Point::Point(100.0, 50.0),
+    Point(100.0, 50.0),
     14.0,
     @color.white(),
   )
   doc = doc.render_text(
     "Radial Gradient",
-    @vg.Point::Point(250.0, 50.0),
+    Point(250.0, 50.0),
     14.0,
     @color.white(),
   )
   doc = doc.render_text(
     "Conic Gradient",
-    @vg.Point::Point(400.0, 50.0),
+    Point(400.0, 50.0),
     14.0,
     @color.white(),
   )
@@ -778,40 +752,36 @@ test "gradient gallery" (it : @test.Test) {
   doc = doc
     .render_linear_gradient(
       "grad1",
-      @vg.Point::Point(0.0, 0.0),
-      @vg.Point::Point(100.0, 0.0),
+      Point(0.0, 0.0),
+      Point(100.0, 0.0),
       @color.red(),
       @color.blue(),
     )
     .render_linear_gradient(
       "grad2",
-      @vg.Point::Point(50.0, 0.0),
-      @vg.Point::Point(50.0, 100.0),
+      Point(50.0, 0.0),
+      Point(50.0, 100.0),
       @color.yellow(),
       @color.purple(),
     )
     .render_linear_gradient(
       "grad3",
-      @vg.Point::Point(0.0, 0.0),
-      @vg.Point::Point(100.0, 100.0),
+      Point(0.0, 0.0),
+      Point(100.0, 100.0),
       @color.cyan(),
       @color.magenta(),
     )
 
   // Draw circles with solid colors representing gradients
-  doc = doc.render_circle(@vg.Point::Point(100.0, 150.0), 60.0, @color.red())
-  doc = doc.render_circle(@vg.Point::Point(100.0, 150.0), 40.0, @color.purple())
-  doc = doc.render_circle(@vg.Point::Point(100.0, 150.0), 20.0, @color.blue())
-  doc = doc.render_circle(@vg.Point::Point(250.0, 150.0), 60.0, @color.purple())
-  doc = doc.render_circle(@vg.Point::Point(250.0, 150.0), 40.0, @color.orange())
-  doc = doc.render_circle(@vg.Point::Point(250.0, 150.0), 20.0, @color.yellow())
-  doc = doc.render_circle(
-    @vg.Point::Point(400.0, 150.0),
-    60.0,
-    @color.magenta(),
-  )
-  doc = doc.render_circle(@vg.Point::Point(400.0, 150.0), 40.0, @color.white())
-  doc = doc.render_circle(@vg.Point::Point(400.0, 150.0), 20.0, @color.cyan())
+  doc = doc.render_circle(Point(100.0, 150.0), 60.0, @color.red())
+  doc = doc.render_circle(Point(100.0, 150.0), 40.0, @color.purple())
+  doc = doc.render_circle(Point(100.0, 150.0), 20.0, @color.blue())
+  doc = doc.render_circle(Point(250.0, 150.0), 60.0, @color.purple())
+  doc = doc.render_circle(Point(250.0, 150.0), 40.0, @color.orange())
+  doc = doc.render_circle(Point(250.0, 150.0), 20.0, @color.yellow())
+  doc = doc.render_circle(Point(400.0, 150.0), 60.0, @color.magenta())
+  doc = doc.render_circle(Point(400.0, 150.0), 40.0, @color.white())
+  doc = doc.render_circle(Point(400.0, 150.0), 20.0, @color.cyan())
 
   // Display gradient types as image samples
   let _grad_svg1 = linear_grad.render_image_to_svg(80.0, 80.0, 20)
@@ -821,7 +791,7 @@ test "gradient gallery" (it : @test.Test) {
   // Labels for bottom row
   doc = doc.render_text(
     "Image Gradients",
-    @vg.Point::Point(250.0, 280.0),
+    Point(250.0, 280.0),
     16.0,
     @color.white(),
   )

--- a/advanced_test.mbt
+++ b/advanced_test.mbt
@@ -3,9 +3,9 @@
 ///|
 test "quadratic bezier curves" (it : @test.Test) {
   let qcurve_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 50.0))
-    .qcurve_to(@vg.Point::Point(50.0, 10.0), @vg.Point::Point(90.0, 50.0)) // Arch shape
-    .qcurve_to(@vg.Point::Point(50.0, 90.0), @vg.Point::Point(10.0, 50.0)) // Return with opposite arch
+    .move_to(Point(10.0, 50.0))
+    .qcurve_to(Point(50.0, 10.0), Point(90.0, 50.0)) // Arch shape
+    .qcurve_to(Point(50.0, 90.0), Point(10.0, 50.0)) // Return with opposite arch
     .close_path()
   debug_inspect(
     qcurve_path,
@@ -31,9 +31,9 @@ test "quadratic bezier curves" (it : @test.Test) {
 ///|
 test "elliptical arcs" (it : @test.Test) {
   let arc_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(20.0, 50.0))
-    .earc_to(30.0, 20.0, 0.0, false, true, @vg.Point::Point(80.0, 50.0)) // Elliptical arc
-    .earc_to(30.0, 20.0, 0.0, false, true, @vg.Point::Point(20.0, 50.0)) // Return arc
+    .move_to(Point(20.0, 50.0))
+    .earc_to(30.0, 20.0, 0.0, false, true, Point(80.0, 50.0)) // Elliptical arc
+    .earc_to(30.0, 20.0, 0.0, false, true, Point(20.0, 50.0)) // Return arc
     .close_path()
   debug_inspect(
     arc_path,
@@ -59,20 +59,10 @@ test "elliptical arcs" (it : @test.Test) {
 ///|
 test "smooth curve stitching" (it : @test.Test) {
   let smooth_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 50.0))
-    .curve_to(
-      @vg.Point::Point(30.0, 10.0),
-      @vg.Point::Point(50.0, 10.0),
-      @vg.Point::Point(70.0, 50.0),
-    )
-    .smooth_ccurve_to(
-      @vg.Point::Point(110.0, 90.0),
-      @vg.Point::Point(130.0, 50.0),
-    ) // Smooth continuation
-    .smooth_ccurve_to(
-      @vg.Point::Point(150.0, 10.0),
-      @vg.Point::Point(170.0, 50.0),
-    ) // Another smooth curve
+    .move_to(Point(10.0, 50.0))
+    .curve_to(Point(30.0, 10.0), Point(50.0, 10.0), Point(70.0, 50.0))
+    .smooth_ccurve_to(Point(110.0, 90.0), Point(130.0, 50.0)) // Smooth continuation
+    .smooth_ccurve_to(Point(150.0, 10.0), Point(170.0, 50.0)) // Another smooth curve
   debug_inspect(
     smooth_path,
     content=(
@@ -99,8 +89,8 @@ test "axial gradients" (it : @test.Test) {
   let axial_img = @vg.Image::axial_gradient(
     @color.red(),
     @color.yellow(),
-    @vg.Point::Point(-50.0, 0.0),
-    @vg.Point::Point(50.0, 0.0),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
   )
   let axial_svg = axial_img.render_image_to_svg(100.0, 60.0, 25)
   it.write(axial_svg)
@@ -112,7 +102,7 @@ test "conic gradients" (it : @test.Test) {
   let conic_img = @vg.Image::conic_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     0.0,
   )
   let conic_svg = conic_img.render_image_to_svg(100.0, 100.0, 30)
@@ -173,63 +163,38 @@ test "advanced path showcase" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 400.0, 300.0, @color.gray(0.98))
     .render_text(
       "Advanced Path Features",
-      @vg.Point::Point(200.0, 30.0),
+      Point(200.0, 30.0),
       18.0,
       @color.black(),
     )
 
   // Quadratic curve example
   let q_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 80.0))
-    .qcurve_to(@vg.Point::Point(100.0, 50.0), @vg.Point::Point(150.0, 80.0))
-    .qcurve_to(@vg.Point::Point(100.0, 110.0), @vg.Point::Point(50.0, 80.0))
+    .move_to(Point(50.0, 80.0))
+    .qcurve_to(Point(100.0, 50.0), Point(150.0, 80.0))
+    .qcurve_to(Point(100.0, 110.0), Point(50.0, 80.0))
     .close_path()
 
   // Elliptical arc example
   let arc_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(200.0, 80.0))
-    .earc_to(40.0, 25.0, 0.0, false, true, @vg.Point::Point(280.0, 80.0))
-    .earc_to(40.0, 25.0, 0.0, false, true, @vg.Point::Point(200.0, 80.0))
+    .move_to(Point(200.0, 80.0))
+    .earc_to(40.0, 25.0, 0.0, false, true, Point(280.0, 80.0))
+    .earc_to(40.0, 25.0, 0.0, false, true, Point(200.0, 80.0))
     .close_path()
 
   // Smooth curves example
   let smooth_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 150.0))
-    .curve_to(
-      @vg.Point::Point(75.0, 120.0),
-      @vg.Point::Point(100.0, 120.0),
-      @vg.Point::Point(125.0, 150.0),
-    )
-    .smooth_ccurve_to(
-      @vg.Point::Point(175.0, 180.0),
-      @vg.Point::Point(200.0, 150.0),
-    )
-    .smooth_ccurve_to(
-      @vg.Point::Point(225.0, 120.0),
-      @vg.Point::Point(250.0, 150.0),
-    )
+    .move_to(Point(50.0, 150.0))
+    .curve_to(Point(75.0, 120.0), Point(100.0, 120.0), Point(125.0, 150.0))
+    .smooth_ccurve_to(Point(175.0, 180.0), Point(200.0, 150.0))
+    .smooth_ccurve_to(Point(225.0, 120.0), Point(250.0, 150.0))
   let final_doc = doc
     .render_path(q_path, @color.blue())
     .render_path(arc_path, @color.green())
     .render_path(smooth_path, @color.red())
-    .render_text(
-      "Quadratic",
-      @vg.Point::Point(100.0, 130.0),
-      12.0,
-      @color.blue(),
-    )
-    .render_text(
-      "Elliptical Arc",
-      @vg.Point::Point(240.0, 130.0),
-      12.0,
-      @color.green(),
-    )
-    .render_text(
-      "Smooth Curves",
-      @vg.Point::Point(150.0, 200.0),
-      12.0,
-      @color.red(),
-    )
+    .render_text("Quadratic", Point(100.0, 130.0), 12.0, @color.blue())
+    .render_text("Elliptical Arc", Point(240.0, 130.0), 12.0, @color.green())
+    .render_text("Smooth Curves", Point(150.0, 200.0), 12.0, @color.red())
   let svg_string = final_doc.to_string()
   it.write(svg_string)
   it.snapshot(filename="advanced_paths.svg")

--- a/canvas/canvas.mbt
+++ b/canvas/canvas.mbt
@@ -34,17 +34,17 @@ fn path_to_canvas_commands(path : @geometry.Path) -> Array[String] {
   commands.push("ctx.beginPath();")
   for segment in path.0 {
     match segment {
-      @geometry.MoveTo(p) => commands.push("ctx.moveTo(\{p.x}, \{p.y});")
-      @geometry.LineTo(p) => commands.push("ctx.lineTo(\{p.x}, \{p.y});")
-      @geometry.CurveTo(cp1, cp2, end) =>
+      MoveTo(p) => commands.push("ctx.moveTo(\{p.x}, \{p.y});")
+      LineTo(p) => commands.push("ctx.lineTo(\{p.x}, \{p.y});")
+      CurveTo(cp1, cp2, end) =>
         commands.push(
           "ctx.bezierCurveTo(\{cp1.x}, \{cp1.y}, \{cp2.x}, \{cp2.y}, \{end.x}, \{end.y});",
         )
-      @geometry.QCurveTo(cp, end) =>
+      QCurveTo(cp, end) =>
         commands.push(
           "ctx.quadraticCurveTo(\{cp.x}, \{cp.y}, \{end.x}, \{end.y});",
         )
-      @geometry.EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
+      EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
         // Canvas doesn't have native elliptical arcs, approximate with arc and transformations
         commands.push(
           "// Elliptical arc: rx=" +
@@ -61,7 +61,7 @@ fn path_to_canvas_commands(path : @geometry.Path) -> Array[String] {
         )
         commands.push("ctx.restore();")
       }
-      @geometry.Close => commands.push("ctx.closePath();")
+      Close => commands.push("ctx.closePath();")
     }
   }
   commands

--- a/example_test.mbt
+++ b/example_test.mbt
@@ -66,14 +66,10 @@ test "complete workflow - create and render image" {
 test "path to SVG integration" {
   // Create a complex path
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 50.0))
-    .line_to(@vg.Point::Point(100.0, 50.0))
-    .curve_to(
-      @vg.Point::Point(125.0, 50.0),
-      @vg.Point::Point(125.0, 75.0),
-      @vg.Point::Point(100.0, 75.0),
-    )
-    .line_to(@vg.Point::Point(50.0, 75.0))
+    .move_to(Point(50.0, 50.0))
+    .line_to(Point(100.0, 50.0))
+    .curve_to(Point(125.0, 50.0), Point(125.0, 75.0), Point(100.0, 75.0))
+    .line_to(Point(50.0, 75.0))
     .close_path()
 
   // Render to SVG
@@ -92,14 +88,14 @@ test "gradient rendering" {
   let gradient_img = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-50.0, 0.0),
-    @vg.Point::Point(50.0, 0.0),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
   )
 
   // Test gradient at different points
-  let left = gradient_img(@vg.Point::Point(-50.0, 0.0))
-  let center = gradient_img(@vg.Point::Point(0.0, 0.0))
-  let right = gradient_img(@vg.Point::Point(50.0, 0.0))
+  let left = gradient_img(Point(-50.0, 0.0))
+  let center = gradient_img(Point(0.0, 0.0))
+  let right = gradient_img(Point(50.0, 0.0))
   if left != @color.red() {
     fail("Gradient left should be red")
   }
@@ -123,8 +119,8 @@ test "transformation chain" {
   let transformed = rotated.translate_img(20.0, 10.0)
 
   // Test that transformations work
-  let origin_color = transformed(@vg.Point::Point(0.0, 0.0))
-  let translated_center = transformed(@vg.Point::Point(20.0, 10.0))
+  let origin_color = transformed(Point(0.0, 0.0))
+  let translated_center = transformed(Point(20.0, 10.0))
   if origin_color.a > 0.1 {
     fail("Origin should be mostly transparent after transformation")
   }
@@ -166,133 +162,70 @@ test "complete vg library showcase" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 600.0, 500.0, @color.gray(0.97)) // Light background
     .render_text(
       "MoonBit VG Library - Complete Showcase",
-      @vg.Point::Point(300.0, 40.0),
+      Point(300.0, 40.0),
       20.0,
       @color.black(),
     )
 
     // Section 1: Basic Shapes
-    .render_text(
-      "Basic Shapes",
-      @vg.Point::Point(100.0, 70.0),
-      16.0,
-      @color.black(),
-    )
-    .render_circle(@vg.Point::Point(80.0, 110.0), 25.0, @color.red())
+    .render_text("Basic Shapes", Point(100.0, 70.0), 16.0, @color.black())
+    .render_circle(Point(80.0, 110.0), 25.0, @color.red())
     .render_rectangle(130.0, 85.0, 50.0, 50.0, @color.green())
-    .render_ellipse(@vg.Point::Point(230.0, 110.0), 35.0, 20.0, @color.blue())
+    .render_ellipse(Point(230.0, 110.0), 35.0, 20.0, @color.blue())
 
     // Section 2: Complex Shapes (Polygons)
-    .render_text(
-      "Polygons",
-      @vg.Point::Point(350.0, 70.0),
-      16.0,
-      @color.black(),
-    )
+    .render_text("Polygons", Point(350.0, 70.0), 16.0, @color.black())
     .render_polygon(
       [ // Pentagon
-        @vg.Point::Point(330.0, 95.0),
-        @vg.Point::Point(370.0, 95.0),
-        @vg.Point::Point(375.0, 118.0),
-        @vg.Point::Point(350.0, 130.0),
-        @vg.Point::Point(325.0, 118.0),
+        Point(330.0, 95.0),
+        Point(370.0, 95.0),
+        Point(375.0, 118.0),
+        Point(350.0, 130.0),
+        Point(325.0, 118.0),
       ],
       @color.orange(),
     )
     .render_polygon(
       [ // Triangle
-        @vg.Point::Point(420.0, 90.0),
-        @vg.Point::Point(400.0, 130.0),
-        @vg.Point::Point(440.0, 130.0),
+        Point(420.0, 90.0),
+        Point(400.0, 130.0),
+        Point(440.0, 130.0),
       ],
       @color.purple(),
     )
     .render_polygon(
       [ // Diamond
-        @vg.Point::Point(490.0, 90.0),
-        @vg.Point::Point(505.0, 110.0),
-        @vg.Point::Point(490.0, 130.0),
-        @vg.Point::Point(475.0, 110.0),
+        Point(490.0, 90.0),
+        Point(505.0, 110.0),
+        Point(490.0, 130.0),
+        Point(475.0, 110.0),
       ],
       @color.cyan(),
     )
 
     // Section 3: Lines and Strokes
-    .render_text(
-      "Lines & Strokes",
-      @vg.Point::Point(100.0, 180.0),
-      16.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 210.0),
-      @vg.Point::Point(250.0, 210.0),
-      @color.black(),
-      3.0,
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 230.0),
-      @vg.Point::Point(200.0, 250.0),
-      @color.red(),
-      2.0,
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 270.0),
-      @vg.Point::Point(150.0, 230.0),
-      @color.blue(),
-      4.0,
-    )
+    .render_text("Lines & Strokes", Point(100.0, 180.0), 16.0, @color.black())
+    .render_line(Point(50.0, 210.0), Point(250.0, 210.0), @color.black(), 3.0)
+    .render_line(Point(50.0, 230.0), Point(200.0, 250.0), @color.red(), 2.0)
+    .render_line(Point(50.0, 270.0), Point(150.0, 230.0), @color.blue(), 4.0)
 
     // Section 4: Complex Paths
-    .render_text(
-      "Custom Paths",
-      @vg.Point::Point(350.0, 180.0),
-      16.0,
-      @color.black(),
-    )
+    .render_text("Custom Paths", Point(350.0, 180.0), 16.0, @color.black())
 
   // Create complex paths
   let wave_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(300.0, 220.0))
-    .curve_to(
-      @vg.Point::Point(320.0, 200.0),
-      @vg.Point::Point(340.0, 240.0),
-      @vg.Point::Point(360.0, 220.0),
-    )
-    .curve_to(
-      @vg.Point::Point(380.0, 200.0),
-      @vg.Point::Point(400.0, 240.0),
-      @vg.Point::Point(420.0, 220.0),
-    )
-    .curve_to(
-      @vg.Point::Point(440.0, 200.0),
-      @vg.Point::Point(460.0, 240.0),
-      @vg.Point::Point(480.0, 220.0),
-    )
+    .move_to(Point(300.0, 220.0))
+    .curve_to(Point(320.0, 200.0), Point(340.0, 240.0), Point(360.0, 220.0))
+    .curve_to(Point(380.0, 200.0), Point(400.0, 240.0), Point(420.0, 220.0))
+    .curve_to(Point(440.0, 200.0), Point(460.0, 240.0), Point(480.0, 220.0))
   let heart_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(380.0, 270.0))
-    .curve_to(
-      @vg.Point::Point(370.0, 260.0),
-      @vg.Point::Point(355.0, 260.0),
-      @vg.Point::Point(345.0, 270.0),
-    )
-    .curve_to(
-      @vg.Point::Point(335.0, 280.0),
-      @vg.Point::Point(335.0, 295.0),
-      @vg.Point::Point(345.0, 305.0),
-    )
-    .line_to(@vg.Point::Point(380.0, 340.0))
-    .line_to(@vg.Point::Point(415.0, 305.0))
-    .curve_to(
-      @vg.Point::Point(425.0, 295.0),
-      @vg.Point::Point(425.0, 280.0),
-      @vg.Point::Point(415.0, 270.0),
-    )
-    .curve_to(
-      @vg.Point::Point(405.0, 260.0),
-      @vg.Point::Point(390.0, 260.0),
-      @vg.Point::Point(380.0, 270.0),
-    )
+    .move_to(Point(380.0, 270.0))
+    .curve_to(Point(370.0, 260.0), Point(355.0, 260.0), Point(345.0, 270.0))
+    .curve_to(Point(335.0, 280.0), Point(335.0, 295.0), Point(345.0, 305.0))
+    .line_to(Point(380.0, 340.0))
+    .line_to(Point(415.0, 305.0))
+    .curve_to(Point(425.0, 295.0), Point(425.0, 280.0), Point(415.0, 270.0))
+    .curve_to(Point(405.0, 260.0), Point(390.0, 260.0), Point(380.0, 270.0))
     .close_path()
   let final_doc = doc
     .render_path(wave_path, @color.magenta())
@@ -301,51 +234,26 @@ test "complete vg library showcase" (it : @test.Test) {
     // Section 5: Text and Typography
     .render_text(
       "Typography Examples",
-      @vg.Point::Point(100.0, 320.0),
+      Point(100.0, 320.0),
       16.0,
       @color.black(),
     )
-    .render_text(
-      "Regular Text",
-      @vg.Point::Point(100.0, 350.0),
-      12.0,
-      @color.black(),
-    )
-    .render_text(
-      "Colored Text",
-      @vg.Point::Point(200.0, 350.0),
-      12.0,
-      @color.blue(),
-    )
-    .render_text(
-      "Large Text",
-      @vg.Point::Point(100.0, 380.0),
-      18.0,
-      @color.green(),
-    )
-    .render_text(
-      "Purple Text",
-      @vg.Point::Point(250.0, 380.0),
-      14.0,
-      @color.purple(),
-    )
+    .render_text("Regular Text", Point(100.0, 350.0), 12.0, @color.black())
+    .render_text("Colored Text", Point(200.0, 350.0), 12.0, @color.blue())
+    .render_text("Large Text", Point(100.0, 380.0), 18.0, @color.green())
+    .render_text("Purple Text", Point(250.0, 380.0), 14.0, @color.purple())
 
     // Footer
-    .render_line(
-      @vg.Point::Point(50.0, 420.0),
-      @vg.Point::Point(550.0, 420.0),
-      @color.gray(0.7),
-      1.0,
-    )
+    .render_line(Point(50.0, 420.0), Point(550.0, 420.0), @color.gray(0.7), 1.0)
     .render_text(
       "Generated by MoonBit VG - Declarative 2D Vector Graphics",
-      @vg.Point::Point(300.0, 450.0),
+      Point(300.0, 450.0),
       12.0,
       @color.gray(0.5),
     )
     .render_text(
       "Snapshot Testing Showcase",
-      @vg.Point::Point(300.0, 470.0),
+      Point(300.0, 470.0),
       10.0,
       @color.gray(0.6),
     )

--- a/geometry/path.mbt
+++ b/geometry/path.mbt
@@ -117,23 +117,23 @@ pub fn Path::circle(center : Point, radius : Double) -> Path {
   Path::empty()
   .move_to(top)
   .curve_to(
-    Point::Point(center.x + offset, center.y - radius),
-    Point::Point(center.x + radius, center.y - offset),
+    Point(center.x + offset, center.y - radius),
+    Point(center.x + radius, center.y - offset),
     right,
   )
   .curve_to(
-    Point::Point(center.x + radius, center.y + offset),
-    Point::Point(center.x + offset, center.y + radius),
+    Point(center.x + radius, center.y + offset),
+    Point(center.x + offset, center.y + radius),
     bottom,
   )
   .curve_to(
-    Point::Point(center.x - offset, center.y + radius),
-    Point::Point(center.x - radius, center.y + offset),
+    Point(center.x - offset, center.y + radius),
+    Point(center.x - radius, center.y + offset),
     left,
   )
   .curve_to(
-    Point::Point(center.x - radius, center.y - offset),
-    Point::Point(center.x - offset, center.y - radius),
+    Point(center.x - radius, center.y - offset),
+    Point(center.x - offset, center.y - radius),
     top,
   )
   .close_path()
@@ -152,23 +152,23 @@ pub fn Path::ellipse(center : Point, rx : Double, ry : Double) -> Path {
   Path::empty()
   .move_to(top)
   .curve_to(
-    Point::Point(center.x + offset_x, center.y - ry),
-    Point::Point(center.x + rx, center.y - offset_y),
+    Point(center.x + offset_x, center.y - ry),
+    Point(center.x + rx, center.y - offset_y),
     right,
   )
   .curve_to(
-    Point::Point(center.x + rx, center.y + offset_y),
-    Point::Point(center.x + offset_x, center.y + ry),
+    Point(center.x + rx, center.y + offset_y),
+    Point(center.x + offset_x, center.y + ry),
     bottom,
   )
   .curve_to(
-    Point::Point(center.x - offset_x, center.y + ry),
-    Point::Point(center.x - rx, center.y + offset_y),
+    Point(center.x - offset_x, center.y + ry),
+    Point(center.x - rx, center.y + offset_y),
     left,
   )
   .curve_to(
-    Point::Point(center.x - rx, center.y - offset_y),
-    Point::Point(center.x - offset_x, center.y - ry),
+    Point(center.x - rx, center.y - offset_y),
+    Point(center.x - offset_x, center.y - ry),
     top,
   )
   .close_path()
@@ -238,7 +238,7 @@ pub fn Path::smooth_ccurve_to(self : Path, cp2 : Point, end : Point) -> Path {
           // Reflect the previous control point
           let reflected_x = 2.0 * prev_end.x - prev_cp2.x
           let reflected_y = 2.0 * prev_end.y - prev_cp2.y
-          Point::Point(reflected_x, reflected_y)
+          Point(reflected_x, reflected_y)
         }
         _ => cp2 // Not a curve, use cp2
       }
@@ -264,7 +264,7 @@ pub fn Path::smooth_qcurve_to(self : Path, end : Point) -> Path {
           // Reflect the previous control point
           let reflected_x = 2.0 * prev_end.x - prev_cp.x
           let reflected_y = 2.0 * prev_end.y - prev_cp.y
-          Point::Point(reflected_x, reflected_y)
+          Point(reflected_x, reflected_y)
         }
         _ => end // Not a quadratic curve, use end point
       }

--- a/geometry/path_test.mbt
+++ b/geometry/path_test.mbt
@@ -11,9 +11,9 @@ test "empty path creation" {
 ///|
 test "path building with move_to and line_to" {
   let path = @geometry.Path::empty()
-    .move_to(@geometry.Point::Point(0.0, 0.0))
-    .line_to(@geometry.Point::Point(10.0, 0.0))
-    .line_to(@geometry.Point::Point(10.0, 10.0))
+    .move_to(Point(0.0, 0.0))
+    .line_to(Point(10.0, 0.0))
+    .line_to(Point(10.0, 10.0))
     .close_path()
   debug_inspect(
     path,
@@ -33,12 +33,8 @@ test "path building with move_to and line_to" {
 ///|
 test "curve_to segment" {
   let path = @geometry.Path::empty()
-    .move_to(@geometry.Point::Point(0.0, 0.0))
-    .curve_to(
-      @geometry.Point::Point(5.0, 0.0),
-      @geometry.Point::Point(10.0, 5.0),
-      @geometry.Point::Point(10.0, 10.0),
-    )
+    .move_to(Point(0.0, 0.0))
+    .curve_to(Point(5.0, 0.0), Point(10.0, 5.0), Point(10.0, 10.0))
   debug_inspect(
     path,
     content=(
@@ -73,7 +69,7 @@ test "rectangle path" {
 
 ///|
 test "circle path approximation" {
-  let path = @geometry.Path::circle(@geometry.Point::Point(5.0, 5.0), 3.0)
+  let path = @geometry.Path::circle(Point(5.0, 5.0), 3.0)
 
   // Circle approximation uses 4 cubic bezier curves + MoveTo + Close
   if path.0.length() != 6 {
@@ -103,7 +99,7 @@ test "circle path approximation" {
 
 ///|
 test "ellipse path" {
-  let path = @geometry.Path::ellipse(@geometry.Point::Point(0.0, 0.0), 5.0, 3.0)
+  let path = @geometry.Path::ellipse(Point(0.0, 0.0), 5.0, 3.0)
   if path.0.length() != 6 {
     fail("Ellipse path should have 6 segments")
   }
@@ -120,9 +116,9 @@ test "ellipse path" {
 ///|
 test "path bounds calculation" {
   let path = @geometry.Path::empty()
-    .move_to(@geometry.Point::Point(-5.0, -3.0))
-    .line_to(@geometry.Point::Point(10.0, 7.0))
-    .line_to(@geometry.Point::Point(2.0, -8.0))
+    .move_to(Point(-5.0, -3.0))
+    .line_to(Point(10.0, 7.0))
+    .line_to(Point(2.0, -8.0))
   match path.bounds() {
     Some(bounds) =>
       if bounds.min_x != -5.0 ||
@@ -151,22 +147,15 @@ test "path with only close segment" {
 test "comprehensive path shapes" {
   let shapes = [
     ("rectangle", @geometry.Path::rect(0.0, 0.0, 10.0, 5.0)),
-    ("circle", @geometry.Path::circle(@geometry.Point::Point(5.0, 5.0), 3.0)),
-    (
-      "ellipse",
-      @geometry.Path::ellipse(@geometry.Point::Point(0.0, 0.0), 5.0, 3.0),
-    ),
+    ("circle", @geometry.Path::circle(Point(5.0, 5.0), 3.0)),
+    ("ellipse", @geometry.Path::ellipse(Point(0.0, 0.0), 5.0, 3.0)),
     (
       "complex_path",
       @geometry.Path::empty()
-      .move_to(@geometry.Point::Point(0.0, 0.0))
-      .line_to(@geometry.Point::Point(10.0, 0.0))
-      .curve_to(
-        @geometry.Point::Point(15.0, 0.0),
-        @geometry.Point::Point(15.0, 5.0),
-        @geometry.Point::Point(10.0, 5.0),
-      )
-      .line_to(@geometry.Point::Point(0.0, 5.0))
+      .move_to(Point(0.0, 0.0))
+      .line_to(Point(10.0, 0.0))
+      .curve_to(Point(15.0, 0.0), Point(15.0, 5.0), Point(10.0, 5.0))
+      .line_to(Point(0.0, 5.0))
       .close_path(),
     ),
   ]
@@ -267,11 +256,11 @@ test "path bounds calculation with curves" {
     (
       "simple_line",
       @geometry.Path::empty()
-      .move_to(@geometry.Point::Point(-5.0, -3.0))
-      .line_to(@geometry.Point::Point(10.0, 7.0)),
+      .move_to(Point(-5.0, -3.0))
+      .line_to(Point(10.0, 7.0)),
       @geometry.Path::empty()
-      .move_to(@geometry.Point::Point(-5.0, -3.0))
-      .line_to(@geometry.Point::Point(10.0, 7.0))
+      .move_to(Point(-5.0, -3.0))
+      .line_to(Point(10.0, 7.0))
       .bounds(),
     ),
     (
@@ -281,8 +270,8 @@ test "path bounds calculation with curves" {
     ),
     (
       "circle_bounds",
-      @geometry.Path::circle(@geometry.Point::Point(0.0, 0.0), 5.0),
-      @geometry.Path::circle(@geometry.Point::Point(0.0, 0.0), 5.0).bounds(),
+      @geometry.Path::circle(Point(0.0, 0.0), 5.0),
+      @geometry.Path::circle(Point(0.0, 0.0), 5.0).bounds(),
     ),
   ]
   debug_inspect(

--- a/geometry/transform.mbt
+++ b/geometry/transform.mbt
@@ -60,10 +60,7 @@ pub fn compose_transforms(t1 : Transform, t2 : Transform) -> Transform {
 ///|
 /// Apply transformation to a point
 pub fn apply(t : Transform, p : Point) -> Point {
-  Point::Point(
-    t.m11 * p.x + t.m12 * p.y + t.m31,
-    t.m21 * p.x + t.m22 * p.y + t.m32,
-  )
+  Point(t.m11 * p.x + t.m12 * p.y + t.m31, t.m21 * p.x + t.m22 * p.y + t.m32)
 }
 
 ///|

--- a/image.mbt
+++ b/image.mbt
@@ -309,10 +309,7 @@ pub fn Image::tile(
       tiled_y
     }
     self(
-      Point::Point(
-        normalized_x - tile_width / 2.0,
-        normalized_y - tile_height / 2.0,
-      ),
+      Point(normalized_x - tile_width / 2.0, normalized_y - tile_height / 2.0),
     )
   }
 }

--- a/image_test.mbt
+++ b/image_test.mbt
@@ -139,8 +139,8 @@ test "linear gradient" {
   let gradient = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-5.0, 0.0),
-    @vg.Point::Point(5.0, 0.0),
+    Point(-5.0, 0.0),
+    Point(5.0, 0.0),
   )
   let left = @vg.Point::Point(-5.0, 0.0) // Should be red
   let right = @vg.Point::Point(5.0, 0.0) // Should be blue
@@ -166,7 +166,7 @@ test "radial gradient" {
   let gradient = @vg.Image::radial_gradient(
     @color.white(),
     @color.black(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     5.0,
   )
   let center = @vg.Point::Point(0.0, 0.0) // Should be white
@@ -230,8 +230,8 @@ test "ellipse image" {
 test "polygon image" {
   let triangle_points = [
     @vg.Point::Point(0.0, -2.0),
-    @vg.Point::Point(-2.0, 2.0),
-    @vg.Point::Point(2.0, 2.0),
+    Point(-2.0, 2.0),
+    Point(2.0, 2.0),
   ]
   let triangle_img = @vg.Image::polygon(@color.blue(), triangle_points)
   let inside = @vg.Point::Point(0.0, 0.0) // Inside triangle
@@ -287,33 +287,33 @@ test "gradient images showcase" (it : @test.Test) {
   let horizontal_gradient = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-50.0, 0.0),
-    @vg.Point::Point(50.0, 0.0),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
   )
   let vertical_gradient = @vg.Image::linear_gradient(
     @color.green(),
     @color.yellow(),
-    @vg.Point::Point(0.0, -40.0),
-    @vg.Point::Point(0.0, 40.0),
+    Point(0.0, -40.0),
+    Point(0.0, 40.0),
   )
   let diagonal_gradient = @vg.Image::linear_gradient(
     @color.purple(),
     @color.cyan(),
-    @vg.Point::Point(-35.0, -35.0),
-    @vg.Point::Point(35.0, 35.0),
+    Point(-35.0, -35.0),
+    Point(35.0, 35.0),
   )
 
   // Radial gradients
   let radial1 = @vg.Image::radial_gradient(
     @color.white(),
     @color.red(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     30.0,
   )
   let radial2 = @vg.Image::radial_gradient(
     @color.yellow(),
     @color.purple(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     25.0,
   )
 

--- a/moon.mod
+++ b/moon.mod
@@ -12,4 +12,4 @@ keywords = [ "graphics", "vector", "2d", "svg", "canvas" ]
 
 description = "Declarative 2D vector graphics library for MoonBit"
 
-warnings = "-unused_constructor-struct_never_constructed"
+warnings = "-unused_constructor-struct_never_constructed+unnecessary_annotation"

--- a/oo_api_test.mbt
+++ b/oo_api_test.mbt
@@ -5,20 +5,10 @@ test "svg oo-style api" (it : @test.Test) {
   // Demonstrate fluent OO-style API for SVG
   let doc = @svg.new_svg(300.0, 200.0)
     .render_rectangle(0.0, 0.0, 300.0, 200.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red())
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red())
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green())
-    .render_text(
-      "OO-Style SVG",
-      @vg.Point::Point(150.0, 40.0),
-      16.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 160.0),
-      @vg.Point::Point(250.0, 160.0),
-      @color.blue(),
-      2.0,
-    )
+    .render_text("OO-Style SVG", Point(150.0, 40.0), 16.0, @color.black())
+    .render_line(Point(50.0, 160.0), Point(250.0, 160.0), @color.blue(), 2.0)
   let svg_string = doc.to_string()
   it.write(svg_string)
   it.snapshot(filename="oo_style_svg.svg")
@@ -29,20 +19,10 @@ test "canvas oo-style api" (it : @test.Test) {
   // Demonstrate fluent OO-style API for Canvas
   let doc = @canvas.new_canvas(300.0, 200.0)
     .render_rectangle(0.0, 0.0, 300.0, 200.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red())
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red())
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green())
-    .render_text(
-      "OO-Style Canvas",
-      @vg.Point::Point(150.0, 40.0),
-      16.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 160.0),
-      @vg.Point::Point(250.0, 160.0),
-      @color.blue(),
-      2.0,
-    )
+    .render_text("OO-Style Canvas", Point(150.0, 40.0), 16.0, @color.black())
+    .render_line(Point(50.0, 160.0), Point(250.0, 160.0), @color.blue(), 2.0)
   let canvas_html = doc.to_html("OO-Style Canvas Demo")
   it.write(canvas_html)
   it.snapshot(filename="oo_style_canvas.html")
@@ -53,20 +33,10 @@ test "pdf oo-style api" (it : @test.Test) {
   // Demonstrate fluent OO-style API for PDF
   let doc = @pdf.PdfDocument::new(300.0, 200.0)
     .render_rectangle(0.0, 0.0, 300.0, 200.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red())
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red())
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green())
-    .render_text(
-      "OO-Style PDF",
-      @vg.Point::Point(150.0, 40.0),
-      16.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 160.0),
-      @vg.Point::Point(250.0, 160.0),
-      @color.blue(),
-      2.0,
-    )
+    .render_text("OO-Style PDF", Point(150.0, 40.0), 16.0, @color.black())
+    .render_line(Point(50.0, 160.0), Point(250.0, 160.0), @color.blue(), 2.0)
   let pdf_string = doc.to_string()
   it.write(pdf_string)
   it.snapshot(filename="oo_style_pdf.pdf")
@@ -76,43 +46,25 @@ test "pdf oo-style api" (it : @test.Test) {
 test "oo-style path with document integration" (it : @test.Test) {
   // Demonstrate how OO-style paths work with OO-style documents
   let custom_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 50.0))
-    .line_to(@vg.Point::Point(150.0, 50.0))
-    .qcurve_to(@vg.Point::Point(200.0, 75.0), @vg.Point::Point(150.0, 100.0))
-    .smooth_ccurve_to(
-      @vg.Point::Point(75.0, 125.0),
-      @vg.Point::Point(50.0, 100.0),
-    )
+    .move_to(Point(50.0, 50.0))
+    .line_to(Point(150.0, 50.0))
+    .qcurve_to(Point(200.0, 75.0), Point(150.0, 100.0))
+    .smooth_ccurve_to(Point(75.0, 125.0), Point(50.0, 100.0))
     .close_path()
 
   // Use the same path across all OO-style renderers
   let svg_doc = @svg.new_svg(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.white())
     .render_path(custom_path, @color.purple())
-    .render_text(
-      "OO Path + SVG",
-      @vg.Point::Point(125.0, 30.0),
-      14.0,
-      @color.black(),
-    )
+    .render_text("OO Path + SVG", Point(125.0, 30.0), 14.0, @color.black())
   let canvas_doc = @canvas.new_canvas(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.white())
     .render_path(custom_path, @color.purple())
-    .render_text(
-      "OO Path + Canvas",
-      @vg.Point::Point(125.0, 30.0),
-      14.0,
-      @color.black(),
-    )
+    .render_text("OO Path + Canvas", Point(125.0, 30.0), 14.0, @color.black())
   let pdf_doc = @pdf.PdfDocument::new(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.white())
     .render_path(custom_path, @color.purple())
-    .render_text(
-      "OO Path + PDF",
-      @vg.Point::Point(125.0, 30.0),
-      14.0,
-      @color.black(),
-    )
+    .render_text("OO Path + PDF", Point(125.0, 30.0), 14.0, @color.black())
 
   // Generate outputs using OO-style methods
   it.write(svg_doc.to_string())
@@ -129,23 +81,13 @@ test "oo-style api comparison" (it : @test.Test) {
 
   // Functional style (original)
   let svg_functional = @svg.new_svg(200.0, 100.0)
-    .render_circle(@vg.Point::Point(100.0, 50.0), 25.0, @color.red())
-    .render_text(
-      "Functional Style",
-      @vg.Point::Point(100.0, 80.0),
-      12.0,
-      @color.black(),
-    )
+    .render_circle(Point(100.0, 50.0), 25.0, @color.red())
+    .render_text("Functional Style", Point(100.0, 80.0), 12.0, @color.black())
 
   // OO style (new)  
   let svg_oo = @svg.new_svg(200.0, 100.0)
-    .render_circle(@vg.Point::Point(100.0, 50.0), 25.0, @color.red())
-    .render_text(
-      "OO Style",
-      @vg.Point::Point(100.0, 80.0),
-      12.0,
-      @color.black(),
-    )
+    .render_circle(Point(100.0, 50.0), 25.0, @color.red())
+    .render_text("OO Style", Point(100.0, 80.0), 12.0, @color.black())
 
   // Get outputs for comparison
   let functional_output = svg_functional.to_string()
@@ -178,43 +120,35 @@ test "oo-style api comparison" (it : @test.Test) {
 test "complete oo-style showcase" (it : @test.Test) {
   // Create a comprehensive demo using only OO-style APIs
   let advanced_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 75.0))
-    .qcurve_to(@vg.Point::Point(100.0, 25.0), @vg.Point::Point(150.0, 75.0))
-    .smooth_ccurve_to(
-      @vg.Point::Point(225.0, 125.0),
-      @vg.Point::Point(275.0, 75.0),
-    )
-    .earc_to(25.0, 15.0, 0.0, false, true, @vg.Point::Point(225.0, 100.0))
+    .move_to(Point(50.0, 75.0))
+    .qcurve_to(Point(100.0, 25.0), Point(150.0, 75.0))
+    .smooth_ccurve_to(Point(225.0, 125.0), Point(275.0, 75.0))
+    .earc_to(25.0, 15.0, 0.0, false, true, Point(225.0, 100.0))
     .close_path()
   let svg_showcase = @svg.new_svg(350.0, 200.0)
     .render_rectangle(0.0, 0.0, 350.0, 200.0, @color.gray(0.98))
     .render_text(
       "Complete OO-Style API Showcase",
-      @vg.Point::Point(175.0, 30.0),
+      Point(175.0, 30.0),
       18.0,
       @color.black(),
     )
     .render_path(advanced_path, @color.blue())
-    .render_circle(@vg.Point::Point(100.0, 150.0), 20.0, @color.red())
+    .render_circle(Point(100.0, 150.0), 20.0, @color.red())
     .render_polygon(
       [
-        @vg.Point::Point(250.0, 130.0),
-        @vg.Point::Point(270.0, 140.0),
-        @vg.Point::Point(265.0, 160.0),
-        @vg.Point::Point(235.0, 160.0),
-        @vg.Point::Point(230.0, 140.0),
+        Point(250.0, 130.0),
+        Point(270.0, 140.0),
+        Point(265.0, 160.0),
+        Point(235.0, 160.0),
+        Point(230.0, 140.0),
       ],
       @color.green(),
     )
-    .render_line(
-      @vg.Point::Point(50.0, 180.0),
-      @vg.Point::Point(300.0, 180.0),
-      @color.purple(),
-      2.0,
-    )
+    .render_line(Point(50.0, 180.0), Point(300.0, 180.0), @color.purple(), 2.0)
     .render_text(
       "Fluent • Modern • Type-Safe",
-      @vg.Point::Point(175.0, 170.0),
+      Point(175.0, 170.0),
       12.0,
       @color.gray(0.6),
     )

--- a/path_test.mbt
+++ b/path_test.mbt
@@ -11,9 +11,9 @@ test "empty path creation" {
 ///|
 test "path building with move_to and line_to" {
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(0.0, 0.0))
-    .line_to(@vg.Point::Point(10.0, 0.0))
-    .line_to(@vg.Point::Point(10.0, 10.0))
+    .move_to(Point(0.0, 0.0))
+    .line_to(Point(10.0, 0.0))
+    .line_to(Point(10.0, 10.0))
     .close_path()
   debug_inspect(
     path,
@@ -33,12 +33,8 @@ test "path building with move_to and line_to" {
 ///|
 test "curve_to segment" {
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(0.0, 0.0))
-    .curve_to(
-      @vg.Point::Point(5.0, 0.0),
-      @vg.Point::Point(10.0, 5.0),
-      @vg.Point::Point(10.0, 10.0),
-    )
+    .move_to(Point(0.0, 0.0))
+    .curve_to(Point(5.0, 0.0), Point(10.0, 5.0), Point(10.0, 10.0))
   debug_inspect(
     path,
     content=(
@@ -73,7 +69,7 @@ test "rectangle path" {
 
 ///|
 test "circle path approximation" {
-  let path = @vg.Path::circle(@vg.Point::Point(5.0, 5.0), 3.0)
+  let path = @vg.Path::circle(Point(5.0, 5.0), 3.0)
 
   // Circle approximation uses 4 cubic bezier curves + MoveTo + Close
   if path.0.length() != 6 {
@@ -103,7 +99,7 @@ test "circle path approximation" {
 
 ///|
 test "ellipse path" {
-  let path = @vg.Path::ellipse(@vg.Point::Point(0.0, 0.0), 5.0, 3.0)
+  let path = @vg.Path::ellipse(Point(0.0, 0.0), 5.0, 3.0)
   if path.0.length() != 6 {
     fail("Ellipse path should have 6 segments")
   }
@@ -137,9 +133,9 @@ test "path transformation" {
 ///|
 test "path bounds calculation" {
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(-5.0, -3.0))
-    .line_to(@vg.Point::Point(10.0, 7.0))
-    .line_to(@vg.Point::Point(2.0, -8.0))
+    .move_to(Point(-5.0, -3.0))
+    .line_to(Point(10.0, 7.0))
+    .line_to(Point(2.0, -8.0))
   match path.bounds() {
     Some(bounds) =>
       if bounds.min_x != -5.0 ||
@@ -168,19 +164,15 @@ test "path with only close segment" {
 test "comprehensive path shapes" {
   let shapes = [
     ("rectangle", @vg.Path::rect(0.0, 0.0, 10.0, 5.0)),
-    ("circle", @vg.Path::circle(@vg.Point::Point(5.0, 5.0), 3.0)),
-    ("ellipse", @vg.Path::ellipse(@vg.Point::Point(0.0, 0.0), 5.0, 3.0)),
+    ("circle", @vg.Path::circle(Point(5.0, 5.0), 3.0)),
+    ("ellipse", @vg.Path::ellipse(Point(0.0, 0.0), 5.0, 3.0)),
     (
       "complex_path",
       @vg.Path::empty()
-      .move_to(@vg.Point::Point(0.0, 0.0))
-      .line_to(@vg.Point::Point(10.0, 0.0))
-      .curve_to(
-        @vg.Point::Point(15.0, 0.0),
-        @vg.Point::Point(15.0, 5.0),
-        @vg.Point::Point(10.0, 5.0),
-      )
-      .line_to(@vg.Point::Point(0.0, 5.0))
+      .move_to(Point(0.0, 0.0))
+      .line_to(Point(10.0, 0.0))
+      .curve_to(Point(15.0, 0.0), Point(15.0, 5.0), Point(10.0, 5.0))
+      .line_to(Point(0.0, 5.0))
       .close_path(),
     ),
   ]
@@ -280,12 +272,10 @@ test "path bounds calculation with curves" {
   let paths_with_bounds = [
     (
       "simple_line",
+      @vg.Path::empty().move_to(Point(-5.0, -3.0)).line_to(Point(10.0, 7.0)),
       @vg.Path::empty()
-      .move_to(@vg.Point::Point(-5.0, -3.0))
-      .line_to(@vg.Point::Point(10.0, 7.0)),
-      @vg.Path::empty()
-      .move_to(@vg.Point::Point(-5.0, -3.0))
-      .line_to(@vg.Point::Point(10.0, 7.0))
+      .move_to(Point(-5.0, -3.0))
+      .line_to(Point(10.0, 7.0))
       .bounds(),
     ),
     (
@@ -295,8 +285,8 @@ test "path bounds calculation with curves" {
     ),
     (
       "circle_bounds",
-      @vg.Path::circle(@vg.Point::Point(0.0, 0.0), 5.0),
-      @vg.Path::circle(@vg.Point::Point(0.0, 0.0), 5.0).bounds(),
+      @vg.Path::circle(Point(0.0, 0.0), 5.0),
+      @vg.Path::circle(Point(0.0, 0.0), 5.0).bounds(),
     ),
   ]
   debug_inspect(

--- a/pdf/pdf.mbt
+++ b/pdf/pdf.mbt
@@ -36,13 +36,13 @@ fn path_to_pdf_commands(
   let commands = Array::new()
   for segment in path.0 {
     match segment {
-      @geometry.MoveTo(p) => commands.push("\{point_to_pdf(p, height)} m")
-      @geometry.LineTo(p) => commands.push("\{point_to_pdf(p, height)} l")
-      @geometry.CurveTo(cp1, cp2, end) =>
+      MoveTo(p) => commands.push("\{point_to_pdf(p, height)} m")
+      LineTo(p) => commands.push("\{point_to_pdf(p, height)} l")
+      CurveTo(cp1, cp2, end) =>
         commands.push(
           "\{point_to_pdf(cp1, height)} \{point_to_pdf(cp2, height)} \{point_to_pdf(end, height)} c",
         )
-      @geometry.QCurveTo(cp, end) => {
+      QCurveTo(cp, end) => {
         // Convert quadratic to cubic Bézier for PDF
         // PDF doesn't support quadratic curves natively
         commands.push("% Quadratic curve converted to cubic")
@@ -50,12 +50,12 @@ fn path_to_pdf_commands(
           "\{point_to_pdf(cp, height)} \{point_to_pdf(cp, height)} \{point_to_pdf(end, height)} c",
         )
       }
-      @geometry.EArcTo(_, _, _, _, _, end) => {
+      EArcTo(_, _, _, _, _, end) => {
         // Simplified arc for PDF - just line to end point
         commands.push("% Elliptical arc simplified")
         commands.push("\{point_to_pdf(end, height)} l")
       }
-      @geometry.Close => commands.push("h") // Close path
+      Close => commands.push("h") // Close path
     }
   }
   commands
@@ -91,53 +91,26 @@ pub fn PdfDocument::render_circle(
   let offset = radius * kappa
   let content = "q\n" + // Save graphics state
     "\{color_to_pdf(color)}\n" +
-    "\{point_to_pdf(@geometry.Point::Point(center.x, center.y - radius), self.height)} m\n" + // Move to top
+    "\{point_to_pdf(Point(center.x, center.y - radius), self.height)} m\n" + // Move to top
     // Four cubic curves to approximate circle
-    "\{point_to_pdf(@geometry.Point::Point(center.x + offset, center.y - radius), self.height)} \{point_to_pdf(@geometry.Point::Point(center.x + radius, center.y - offset), self.height)} \{point_to_pdf(@geometry.Point::Point(center.x + radius, center.y), self.height)} c\n" +
-    point_to_pdf(
-      @geometry.Point::Point(center.x + radius, center.y + offset),
-      self.height,
-    ) +
+    "\{point_to_pdf(Point(center.x + offset, center.y - radius), self.height)} \{point_to_pdf(Point(center.x + radius, center.y - offset), self.height)} \{point_to_pdf(Point(center.x + radius, center.y), self.height)} c\n" +
+    point_to_pdf(Point(center.x + radius, center.y + offset), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x + offset, center.y + radius),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x + offset, center.y + radius), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x, center.y + radius),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x, center.y + radius), self.height) +
     " c\n" +
-    point_to_pdf(
-      @geometry.Point::Point(center.x - offset, center.y + radius),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x - offset, center.y + radius), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x - radius, center.y + offset),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x - radius, center.y + offset), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x - radius, center.y),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x - radius, center.y), self.height) +
     " c\n" +
-    point_to_pdf(
-      @geometry.Point::Point(center.x - radius, center.y - offset),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x - radius, center.y - offset), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x - offset, center.y - radius),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x - offset, center.y - radius), self.height) +
     " " +
-    point_to_pdf(
-      @geometry.Point::Point(center.x, center.y - radius),
-      self.height,
-    ) +
+    point_to_pdf(Point(center.x, center.y - radius), self.height) +
     " c\n" +
     "f\n" + // Fill
     "Q" // Restore graphics state

--- a/renderer_test.mbt
+++ b/renderer_test.mbt
@@ -4,20 +4,10 @@
 test "canvas renderer basic shapes" (it : @test.Test) {
   let doc = @canvas.new_canvas(300.0, 200.0)
     .render_rectangle(10.0, 10.0, 280.0, 180.0, @color.gray(0.9)) // Background
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red()) // Red circle
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red()) // Red circle
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green()) // Green rectangle
-    .render_line(
-      @vg.Point::Point(50.0, 160.0),
-      @vg.Point::Point(250.0, 160.0),
-      @color.blue(),
-      3.0,
-    ) // Blue line
-    .render_text(
-      "Canvas Rendering",
-      @vg.Point::Point(150.0, 40.0),
-      16.0,
-      @color.black(),
-    ) // Title
+    .render_line(Point(50.0, 160.0), Point(250.0, 160.0), @color.blue(), 3.0) // Blue line
+    .render_text("Canvas Rendering", Point(150.0, 40.0), 16.0, @color.black()) // Title
   debug_inspect(
     doc,
     content=(
@@ -58,23 +48,19 @@ test "canvas renderer basic shapes" (it : @test.Test) {
 test "canvas renderer complete html" (it : @test.Test) {
   let doc = @canvas.new_canvas(400.0, 300.0)
     .render_rectangle(0.0, 0.0, 400.0, 300.0, @color.white()) // Background
-    .render_circle(@vg.Point::Point(100.0, 100.0), 40.0, @color.red()) // Red circle
-    .render_circle(
-      @vg.Point::Point(200.0, 100.0),
-      35.0,
-      @color.rgba(0.0, 1.0, 0.0, 0.7),
-    ) // Semi-transparent green
-    .render_circle(@vg.Point::Point(300.0, 100.0), 30.0, @color.blue()) // Blue circle
+    .render_circle(Point(100.0, 100.0), 40.0, @color.red()) // Red circle
+    .render_circle(Point(200.0, 100.0), 35.0, @color.rgba(0.0, 1.0, 0.0, 0.7)) // Semi-transparent green
+    .render_circle(Point(300.0, 100.0), 30.0, @color.blue()) // Blue circle
     .render_rectangle(50.0, 180.0, 300.0, 80.0, @color.rgba(1.0, 1.0, 0.0, 0.5)) // Semi-transparent yellow
     .render_text(
       "HTML5 Canvas VG Demo",
-      @vg.Point::Point(200.0, 50.0),
+      Point(200.0, 50.0),
       20.0,
       @color.black(),
     )
     .render_text(
       "Interactive Graphics",
-      @vg.Point::Point(200.0, 220.0),
+      Point(200.0, 220.0),
       14.0,
       @color.purple(),
     )
@@ -86,20 +72,15 @@ test "canvas renderer complete html" (it : @test.Test) {
 ///|
 test "canvas path rendering" (it : @test.Test) {
   let custom_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 50.0))
-    .line_to(@vg.Point::Point(150.0, 50.0))
-    .qcurve_to(@vg.Point::Point(200.0, 75.0), @vg.Point::Point(150.0, 100.0)) // Quadratic curve
-    .line_to(@vg.Point::Point(50.0, 100.0))
+    .move_to(Point(50.0, 50.0))
+    .line_to(Point(150.0, 50.0))
+    .qcurve_to(Point(200.0, 75.0), Point(150.0, 100.0)) // Quadratic curve
+    .line_to(Point(50.0, 100.0))
     .close_path()
   let doc = @canvas.new_canvas(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.gray(0.95))
     .render_path(custom_path, @color.magenta())
-    .render_text(
-      "Canvas Path Demo",
-      @vg.Point::Point(125.0, 30.0),
-      14.0,
-      @color.black(),
-    )
+    .render_text("Canvas Path Demo", Point(125.0, 30.0), 14.0, @color.black())
   let js_code = doc.to_js()
   it.write(js_code)
   it.snapshot(filename="canvas_path_demo.js")
@@ -109,20 +90,10 @@ test "canvas path rendering" (it : @test.Test) {
 test "pdf renderer basic shapes" (it : @test.Test) {
   let doc = @pdf.PdfDocument::new(300.0, 200.0)
     .render_rectangle(10.0, 10.0, 280.0, 180.0, @color.gray(0.9)) // Background
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red()) // Red circle
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red()) // Red circle
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green()) // Green rectangle
-    .render_line(
-      @vg.Point::Point(50.0, 160.0),
-      @vg.Point::Point(250.0, 160.0),
-      @color.blue(),
-      2.0,
-    ) // Blue line
-    .render_text(
-      "PDF Rendering",
-      @vg.Point::Point(150.0, 40.0),
-      16.0,
-      @color.black(),
-    ) // Title
+    .render_line(Point(50.0, 160.0), Point(250.0, 160.0), @color.blue(), 2.0) // Blue line
+    .render_text("PDF Rendering", Point(150.0, 40.0), 16.0, @color.black()) // Title
   debug_inspect(
     doc,
     content=(
@@ -148,26 +119,21 @@ test "pdf renderer basic shapes" (it : @test.Test) {
 ///|
 test "pdf path rendering" (it : @test.Test) {
   let star_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(100.0, 30.0))
-    .line_to(@vg.Point::Point(110.0, 60.0))
-    .line_to(@vg.Point::Point(140.0, 60.0))
-    .line_to(@vg.Point::Point(118.0, 78.0))
-    .line_to(@vg.Point::Point(128.0, 108.0))
-    .line_to(@vg.Point::Point(100.0, 90.0))
-    .line_to(@vg.Point::Point(72.0, 108.0))
-    .line_to(@vg.Point::Point(82.0, 78.0))
-    .line_to(@vg.Point::Point(60.0, 60.0))
-    .line_to(@vg.Point::Point(90.0, 60.0))
+    .move_to(Point(100.0, 30.0))
+    .line_to(Point(110.0, 60.0))
+    .line_to(Point(140.0, 60.0))
+    .line_to(Point(118.0, 78.0))
+    .line_to(Point(128.0, 108.0))
+    .line_to(Point(100.0, 90.0))
+    .line_to(Point(72.0, 108.0))
+    .line_to(Point(82.0, 78.0))
+    .line_to(Point(60.0, 60.0))
+    .line_to(Point(90.0, 60.0))
     .close_path()
   let doc = @pdf.PdfDocument::new(200.0, 150.0)
     .render_rectangle(0.0, 0.0, 200.0, 150.0, @color.white())
     .render_path(star_path, @color.gold())
-    .render_text(
-      "PDF Star",
-      @vg.Point::Point(100.0, 130.0),
-      12.0,
-      @color.black(),
-    )
+    .render_text("PDF Star", Point(100.0, 130.0), 12.0, @color.black())
   let pdf_content = doc.to_string()
   it.write(pdf_content)
   it.snapshot(filename="pdf_star_demo.pdf")
@@ -180,22 +146,22 @@ test "renderer comparison showcase" (it : @test.Test) {
   // SVG version
   let svg_doc = @svg.new_svg(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(125.0, 75.0), 40.0, @color.red())
-    .render_text("VG Demo", @vg.Point::Point(125.0, 30.0), 16.0, @color.black())
+    .render_circle(Point(125.0, 75.0), 40.0, @color.red())
+    .render_text("VG Demo", Point(125.0, 30.0), 16.0, @color.black())
   let svg_string = svg_doc.to_string()
 
   // Canvas version  
   let canvas_doc = @canvas.new_canvas(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(125.0, 75.0), 40.0, @color.red())
-    .render_text("VG Demo", @vg.Point::Point(125.0, 30.0), 16.0, @color.black())
+    .render_circle(Point(125.0, 75.0), 40.0, @color.red())
+    .render_text("VG Demo", Point(125.0, 30.0), 16.0, @color.black())
   let canvas_html = canvas_doc.to_html("Canvas Demo")
 
   // PDF version
   let pdf_doc = @pdf.PdfDocument::new(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(125.0, 75.0), 40.0, @color.red())
-    .render_text("VG Demo", @vg.Point::Point(125.0, 30.0), 16.0, @color.black())
+    .render_circle(Point(125.0, 75.0), 40.0, @color.red())
+    .render_text("VG Demo", Point(125.0, 30.0), 16.0, @color.black())
   let pdf_string = pdf_doc.to_string()
 
   // Write all three formats
@@ -223,19 +189,12 @@ test "complete feature showcase all renderers" (it : @test.Test) {
 
   // Advanced path with all curve types
   let advanced_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 100.0))
-    .line_to(@vg.Point::Point(100.0, 80.0))
-    .qcurve_to(@vg.Point::Point(125.0, 60.0), @vg.Point::Point(150.0, 80.0)) // Quadratic
-    .curve_to(
-      @vg.Point::Point(175.0, 60.0),
-      @vg.Point::Point(200.0, 120.0),
-      @vg.Point::Point(225.0, 100.0),
-    ) // Cubic
-    .smooth_ccurve_to(
-      @vg.Point::Point(275.0, 60.0),
-      @vg.Point::Point(300.0, 100.0),
-    ) // Smooth
-    .earc_to(25.0, 15.0, 0.0, false, true, @vg.Point::Point(250.0, 120.0)) // Elliptical arc
+    .move_to(Point(50.0, 100.0))
+    .line_to(Point(100.0, 80.0))
+    .qcurve_to(Point(125.0, 60.0), Point(150.0, 80.0)) // Quadratic
+    .curve_to(Point(175.0, 60.0), Point(200.0, 120.0), Point(225.0, 100.0)) // Cubic
+    .smooth_ccurve_to(Point(275.0, 60.0), Point(300.0, 100.0)) // Smooth
+    .earc_to(25.0, 15.0, 0.0, false, true, Point(250.0, 120.0)) // Elliptical arc
     .close_path()
 
   // SVG with all advanced features
@@ -243,25 +202,25 @@ test "complete feature showcase all renderers" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 350.0, 200.0, @color.white())
     .render_text(
       "Complete VG Feature Showcase",
-      @vg.Point::Point(175.0, 30.0),
+      Point(175.0, 30.0),
       16.0,
       @color.black(),
     )
     .render_path(advanced_path, @color.blue())
-    .render_circle(@vg.Point::Point(100.0, 150.0), 20.0, @color.red())
+    .render_circle(Point(100.0, 150.0), 20.0, @color.red())
     .render_polygon(
       [
-        @vg.Point::Point(200.0, 130.0),
-        @vg.Point::Point(220.0, 140.0),
-        @vg.Point::Point(215.0, 160.0),
-        @vg.Point::Point(185.0, 160.0),
-        @vg.Point::Point(180.0, 140.0),
+        Point(200.0, 130.0),
+        Point(220.0, 140.0),
+        Point(215.0, 160.0),
+        Point(185.0, 160.0),
+        Point(180.0, 140.0),
       ],
       @color.green(),
     )
     .render_text(
       "All Features: Paths, Curves, Arcs",
-      @vg.Point::Point(175.0, 180.0),
+      Point(175.0, 180.0),
       12.0,
       @color.purple(),
     )
@@ -271,15 +230,15 @@ test "complete feature showcase all renderers" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 350.0, 200.0, @color.white())
     .render_text(
       "Canvas: Complete VG Features",
-      @vg.Point::Point(175.0, 30.0),
+      Point(175.0, 30.0),
       16.0,
       @color.black(),
     )
     .render_path(advanced_path, @color.blue())
-    .render_circle(@vg.Point::Point(100.0, 150.0), 20.0, @color.red())
+    .render_circle(Point(100.0, 150.0), 20.0, @color.red())
     .render_text(
       "Interactive Graphics Ready",
-      @vg.Point::Point(175.0, 180.0),
+      Point(175.0, 180.0),
       12.0,
       @color.purple(),
     )
@@ -289,15 +248,15 @@ test "complete feature showcase all renderers" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 350.0, 200.0, @color.white())
     .render_text(
       "PDF: Complete VG Features",
-      @vg.Point::Point(175.0, 30.0),
+      Point(175.0, 30.0),
       16.0,
       @color.black(),
     )
     .render_path(advanced_path, @color.blue())
-    .render_circle(@vg.Point::Point(100.0, 150.0), 20.0, @color.red())
+    .render_circle(Point(100.0, 150.0), 20.0, @color.red())
     .render_text(
       "Document Ready Graphics",
-      @vg.Point::Point(175.0, 180.0),
+      Point(175.0, 180.0),
       12.0,
       @color.purple(),
     )

--- a/svg/svg.mbt
+++ b/svg/svg.mbt
@@ -48,20 +48,20 @@ fn path_to_svg_data(path : @geometry.Path) -> String {
   let mut data = ""
   for segment in path.0 {
     match segment {
-      @geometry.MoveTo(p) => data = data + "M \{point_to_svg(p)} "
-      @geometry.LineTo(p) => data = data + "L \{point_to_svg(p)} "
-      @geometry.CurveTo(cp1, cp2, end) =>
+      MoveTo(p) => data = data + "M \{point_to_svg(p)} "
+      LineTo(p) => data = data + "L \{point_to_svg(p)} "
+      CurveTo(cp1, cp2, end) =>
         data = data +
           "C \{point_to_svg(cp1)} \{point_to_svg(cp2)} \{point_to_svg(end)} "
-      @geometry.QCurveTo(cp, end) =>
+      QCurveTo(cp, end) =>
         data = data + "Q \{point_to_svg(cp)} \{point_to_svg(end)} "
-      @geometry.EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
+      EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
         let large_flag = if large_arc { "1" } else { "0" }
         let sweep_flag = if sweep { "1" } else { "0" }
         data = data +
           "A \{rx} \{ry} \{rotation} \{large_flag} \{sweep_flag} \{point_to_svg(end)} "
       }
-      @geometry.Close => data = data + "Z "
+      Close => data = data + "Z "
     }
   }
   data

--- a/svg_test.mbt
+++ b/svg_test.mbt
@@ -24,7 +24,7 @@ test "adding elements to SVG" {
 ///|
 test "circle rendering" (it : @test.Test) {
   let doc = @svg.new_svg(100.0, 100.0).render_circle(
-    @vg.Point::Point(50.0, 50.0),
+    Point(50.0, 50.0),
     25.0,
     @color.red(),
   )
@@ -93,7 +93,7 @@ test "line rendering" {
 test "text rendering" {
   let doc = @svg.new_svg(200.0, 100.0).render_text(
     "Hello World",
-    @vg.Point::Point(50.0, 30.0),
+    Point(50.0, 30.0),
     16.0,
     @color.black(),
   )
@@ -109,7 +109,7 @@ test "text rendering" {
 ///|
 test "SVG string generation" {
   let doc = @svg.new_svg(100.0, 100.0).render_circle(
-    @vg.Point::Point(50.0, 50.0),
+    Point(50.0, 50.0),
     25.0,
     @color.red(),
   )
@@ -135,14 +135,9 @@ test "SVG string generation" {
 test "complex SVG document" {
   let doc = @svg.new_svg(200.0, 200.0)
     .render_rectangle(10.0, 10.0, 180.0, 180.0, @color.gray(0.9))
-    .render_circle(@vg.Point::Point(100.0, 100.0), 50.0, @color.red())
-    .render_line(
-      @vg.Point::Point(50.0, 50.0),
-      @vg.Point::Point(150.0, 150.0),
-      @color.blue(),
-      3.0,
-    )
-    .render_text("Test", @vg.Point::Point(100.0, 180.0), 14.0, @color.black())
+    .render_circle(Point(100.0, 100.0), 50.0, @color.red())
+    .render_line(Point(50.0, 50.0), Point(150.0, 150.0), @color.blue(), 3.0)
+    .render_text("Test", Point(100.0, 180.0), 14.0, @color.black())
   if doc.elements.length() != 4 {
     fail("Complex document should have 4 elements")
   }
@@ -171,7 +166,7 @@ test "image to SVG rendering" {
 test "color with alpha in SVG" {
   let semi_transparent = @color.rgba(1.0, 0.0, 0.0, 0.5)
   let doc = @svg.new_svg(100.0, 100.0).render_circle(
-    @vg.Point::Point(50.0, 50.0),
+    Point(50.0, 50.0),
     25.0,
     semi_transparent,
   )
@@ -191,21 +186,11 @@ test "color with alpha in SVG" {
 test "comprehensive svg rendering" (it : @test.Test) {
   let complex_doc = @svg.new_svg(300.0, 200.0)
     .render_rectangle(10.0, 10.0, 280.0, 180.0, @color.gray(0.95)) // Background
-    .render_circle(@vg.Point::Point(80.0, 60.0), 30.0, @color.red()) // Red circle
-    .render_ellipse(@vg.Point::Point(150.0, 60.0), 25.0, 15.0, @color.blue()) // Blue ellipse
+    .render_circle(Point(80.0, 60.0), 30.0, @color.red()) // Red circle
+    .render_ellipse(Point(150.0, 60.0), 25.0, 15.0, @color.blue()) // Blue ellipse
     .render_rectangle(200.0, 30.0, 40.0, 60.0, @color.green()) // Green rectangle
-    .render_line(
-      @vg.Point::Point(20.0, 120.0),
-      @vg.Point::Point(280.0, 120.0),
-      @color.black(),
-      2.0,
-    ) // Divider line
-    .render_text(
-      "VG Graphics Demo",
-      @vg.Point::Point(150.0, 150.0),
-      16.0,
-      @color.purple(),
-    ) // Title text
+    .render_line(Point(20.0, 120.0), Point(280.0, 120.0), @color.black(), 2.0) // Divider line
+    .render_text("VG Graphics Demo", Point(150.0, 150.0), 16.0, @color.purple()) // Title text
   debug_inspect(
     complex_doc,
     content=(
@@ -231,7 +216,7 @@ test "comprehensive svg rendering" (it : @test.Test) {
 ///|
 test "svg string generation" (it : @test.Test) {
   let doc = @svg.new_svg(100.0, 100.0).render_circle(
-    @vg.Point::Point(50.0, 50.0),
+    Point(50.0, 50.0),
     25.0,
     @color.red(),
   )
@@ -252,14 +237,10 @@ test "svg string generation" (it : @test.Test) {
 ///|
 test "path rendering to svg" (it : @test.Test) {
   let custom_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(10.0, 10.0))
-    .line_to(@vg.Point::Point(90.0, 10.0))
-    .curve_to(
-      @vg.Point::Point(110.0, 10.0),
-      @vg.Point::Point(110.0, 30.0),
-      @vg.Point::Point(90.0, 30.0),
-    )
-    .line_to(@vg.Point::Point(10.0, 30.0))
+    .move_to(Point(10.0, 10.0))
+    .line_to(Point(90.0, 10.0))
+    .curve_to(Point(110.0, 10.0), Point(110.0, 30.0), Point(90.0, 30.0))
+    .line_to(Point(10.0, 30.0))
     .close_path()
   let doc = @svg.new_svg(120.0, 50.0).render_path(custom_path, @color.magenta())
   debug_inspect(
@@ -283,14 +264,14 @@ test "gradient showcase" (it : @test.Test) {
   let gradient_img = @vg.Image::linear_gradient(
     @color.red(),
     @color.blue(),
-    @vg.Point::Point(-50.0, 0.0),
-    @vg.Point::Point(50.0, 0.0),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
   )
   let gradient_svg = gradient_img.render_image_to_svg(100.0, 50.0, 20)
   let radial_img = @vg.Image::radial_gradient(
     @color.yellow(),
     @color.purple(),
-    @vg.Point::Point(0.0, 0.0),
+    Point(0.0, 0.0),
     25.0,
   )
   let radial_svg = radial_img.render_image_to_svg(100.0, 50.0, 20)
@@ -307,89 +288,45 @@ test "gradient showcase" (it : @test.Test) {
 test "shape gallery" (it : @test.Test) {
   let doc = @svg.new_svg(500.0, 400.0)
     .render_rectangle(0.0, 0.0, 500.0, 400.0, @color.gray(0.98)) // Light background
-    .render_text(
-      "VG Shape Gallery",
-      @vg.Point::Point(250.0, 30.0),
-      24.0,
-      @color.black(),
-    )
+    .render_text("VG Shape Gallery", Point(250.0, 30.0), 24.0, @color.black())
 
     // Row 1: Basic shapes
-    .render_circle(@vg.Point::Point(80.0, 100.0), 30.0, @color.red())
+    .render_circle(Point(80.0, 100.0), 30.0, @color.red())
     .render_rectangle(130.0, 70.0, 60.0, 60.0, @color.green())
-    .render_ellipse(@vg.Point::Point(250.0, 100.0), 40.0, 25.0, @color.blue())
+    .render_ellipse(Point(250.0, 100.0), 40.0, 25.0, @color.blue())
 
     // Row 2: Complex shapes
     .render_polygon(
       [
-        @vg.Point::Point(325.0, 80.0),
-        @vg.Point::Point(375.0, 80.0),
-        @vg.Point::Point(385.0, 110.0),
-        @vg.Point::Point(350.0, 125.0),
-        @vg.Point::Point(315.0, 110.0),
+        Point(325.0, 80.0),
+        Point(375.0, 80.0),
+        Point(385.0, 110.0),
+        Point(350.0, 125.0),
+        Point(315.0, 110.0),
       ],
       @color.orange(),
     )
     .render_polygon(
-      [
-        @vg.Point::Point(420.0, 75.0),
-        @vg.Point::Point(395.0, 125.0),
-        @vg.Point::Point(445.0, 125.0),
-      ],
+      [Point(420.0, 75.0), Point(395.0, 125.0), Point(445.0, 125.0)],
       @color.purple(),
     )
 
     // Row 3: Lines and text
-    .render_line(
-      @vg.Point::Point(50.0, 180.0),
-      @vg.Point::Point(450.0, 180.0),
-      @color.black(),
-      3.0,
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 200.0),
-      @vg.Point::Point(450.0, 220.0),
-      @color.cyan(),
-      2.0,
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 240.0),
-      @vg.Point::Point(450.0, 200.0),
-      @color.magenta(),
-      2.0,
-    )
+    .render_line(Point(50.0, 180.0), Point(450.0, 180.0), @color.black(), 3.0)
+    .render_line(Point(50.0, 200.0), Point(450.0, 220.0), @color.cyan(), 2.0)
+    .render_line(Point(50.0, 240.0), Point(450.0, 200.0), @color.magenta(), 2.0)
 
     // Labels
-    .render_text("Circle", @vg.Point::Point(80.0, 150.0), 12.0, @color.black())
-    .render_text(
-      "Rectangle",
-      @vg.Point::Point(160.0, 150.0),
-      12.0,
-      @color.black(),
-    )
-    .render_text(
-      "Ellipse",
-      @vg.Point::Point(250.0, 150.0),
-      12.0,
-      @color.black(),
-    )
-    .render_text(
-      "Pentagon",
-      @vg.Point::Point(350.0, 150.0),
-      12.0,
-      @color.black(),
-    )
-    .render_text(
-      "Triangle",
-      @vg.Point::Point(420.0, 150.0),
-      12.0,
-      @color.black(),
-    )
+    .render_text("Circle", Point(80.0, 150.0), 12.0, @color.black())
+    .render_text("Rectangle", Point(160.0, 150.0), 12.0, @color.black())
+    .render_text("Ellipse", Point(250.0, 150.0), 12.0, @color.black())
+    .render_text("Pentagon", Point(350.0, 150.0), 12.0, @color.black())
+    .render_text("Triangle", Point(420.0, 150.0), 12.0, @color.black())
 
     // Footer
     .render_text(
       "Powered by MoonBit VG Library",
-      @vg.Point::Point(250.0, 350.0),
+      Point(250.0, 350.0),
       14.0,
       @color.gray(0.6),
     )
@@ -404,89 +341,52 @@ test "path showcase" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 400.0, 300.0, @color.gray(0.95))
     .render_text(
       "Path Construction Showcase",
-      @vg.Point::Point(200.0, 30.0),
+      Point(200.0, 30.0),
       18.0,
       @color.black(),
     )
 
   // Complex curved path
   let curved_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(50.0, 80.0))
-    .curve_to(
-      @vg.Point::Point(100.0, 60.0),
-      @vg.Point::Point(150.0, 100.0),
-      @vg.Point::Point(200.0, 80.0),
-    )
-    .curve_to(
-      @vg.Point::Point(250.0, 60.0),
-      @vg.Point::Point(300.0, 100.0),
-      @vg.Point::Point(350.0, 80.0),
-    )
-    .line_to(@vg.Point::Point(350.0, 120.0))
-    .curve_to(
-      @vg.Point::Point(300.0, 140.0),
-      @vg.Point::Point(250.0, 100.0),
-      @vg.Point::Point(200.0, 120.0),
-    )
-    .curve_to(
-      @vg.Point::Point(150.0, 140.0),
-      @vg.Point::Point(100.0, 100.0),
-      @vg.Point::Point(50.0, 120.0),
-    )
+    .move_to(Point(50.0, 80.0))
+    .curve_to(Point(100.0, 60.0), Point(150.0, 100.0), Point(200.0, 80.0))
+    .curve_to(Point(250.0, 60.0), Point(300.0, 100.0), Point(350.0, 80.0))
+    .line_to(Point(350.0, 120.0))
+    .curve_to(Point(300.0, 140.0), Point(250.0, 100.0), Point(200.0, 120.0))
+    .curve_to(Point(150.0, 140.0), Point(100.0, 100.0), Point(50.0, 120.0))
     .close_path()
 
   // Heart shape
   let heart_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(100.0, 180.0))
-    .curve_to(
-      @vg.Point::Point(85.0, 165.0),
-      @vg.Point::Point(65.0, 165.0),
-      @vg.Point::Point(50.0, 180.0),
-    )
-    .curve_to(
-      @vg.Point::Point(35.0, 195.0),
-      @vg.Point::Point(35.0, 215.0),
-      @vg.Point::Point(50.0, 230.0),
-    )
-    .line_to(@vg.Point::Point(100.0, 280.0))
-    .line_to(@vg.Point::Point(150.0, 230.0))
-    .curve_to(
-      @vg.Point::Point(165.0, 215.0),
-      @vg.Point::Point(165.0, 195.0),
-      @vg.Point::Point(150.0, 180.0),
-    )
-    .curve_to(
-      @vg.Point::Point(135.0, 165.0),
-      @vg.Point::Point(115.0, 165.0),
-      @vg.Point::Point(100.0, 180.0),
-    )
+    .move_to(Point(100.0, 180.0))
+    .curve_to(Point(85.0, 165.0), Point(65.0, 165.0), Point(50.0, 180.0))
+    .curve_to(Point(35.0, 195.0), Point(35.0, 215.0), Point(50.0, 230.0))
+    .line_to(Point(100.0, 280.0))
+    .line_to(Point(150.0, 230.0))
+    .curve_to(Point(165.0, 215.0), Point(165.0, 195.0), Point(150.0, 180.0))
+    .curve_to(Point(135.0, 165.0), Point(115.0, 165.0), Point(100.0, 180.0))
     .close_path()
 
   // Star path
   let star_path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(300.0, 170.0))
-    .line_to(@vg.Point::Point(310.0, 200.0))
-    .line_to(@vg.Point::Point(340.0, 200.0))
-    .line_to(@vg.Point::Point(318.0, 218.0))
-    .line_to(@vg.Point::Point(328.0, 248.0))
-    .line_to(@vg.Point::Point(300.0, 230.0))
-    .line_to(@vg.Point::Point(272.0, 248.0))
-    .line_to(@vg.Point::Point(282.0, 218.0))
-    .line_to(@vg.Point::Point(260.0, 200.0))
-    .line_to(@vg.Point::Point(290.0, 200.0))
+    .move_to(Point(300.0, 170.0))
+    .line_to(Point(310.0, 200.0))
+    .line_to(Point(340.0, 200.0))
+    .line_to(Point(318.0, 218.0))
+    .line_to(Point(328.0, 248.0))
+    .line_to(Point(300.0, 230.0))
+    .line_to(Point(272.0, 248.0))
+    .line_to(Point(282.0, 218.0))
+    .line_to(Point(260.0, 200.0))
+    .line_to(Point(290.0, 200.0))
     .close_path()
   let final_doc = doc
     .render_path(curved_path, @color.blue())
     .render_path(heart_path, @color.red())
     .render_path(star_path, @color.gold())
-    .render_text(
-      "Curved Path",
-      @vg.Point::Point(200.0, 150.0),
-      12.0,
-      @color.blue(),
-    )
-    .render_text("Heart", @vg.Point::Point(100.0, 160.0), 12.0, @color.red())
-    .render_text("Star", @vg.Point::Point(300.0, 160.0), 12.0, @color.gold())
+    .render_text("Curved Path", Point(200.0, 150.0), 12.0, @color.blue())
+    .render_text("Heart", Point(100.0, 160.0), 12.0, @color.red())
+    .render_text("Star", Point(300.0, 160.0), 12.0, @color.gold())
   let svg_string = final_doc.to_string()
   it.write(svg_string)
   it.snapshot(filename="path_showcase.svg")
@@ -497,19 +397,9 @@ test "svg rendering validation" (it : @test.Test) {
   // Create a simple test to validate SVG structure
   let doc = @svg.new_svg(200.0, 100.0)
     .render_rectangle(10.0, 10.0, 180.0, 80.0, @color.gray(0.95))
-    .render_circle(@vg.Point::Point(100.0, 50.0), 20.0, @color.red())
-    .render_text(
-      "SVG Test",
-      @vg.Point::Point(100.0, 30.0),
-      14.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(20.0, 80.0),
-      @vg.Point::Point(180.0, 80.0),
-      @color.blue(),
-      2.0,
-    )
+    .render_circle(Point(100.0, 50.0), 20.0, @color.red())
+    .render_text("SVG Test", Point(100.0, 30.0), 14.0, @color.black())
+    .render_line(Point(20.0, 80.0), Point(180.0, 80.0), @color.blue(), 2.0)
   let svg_string = doc.to_string()
 
   // Basic validation checks
@@ -534,14 +424,9 @@ test "minimal svg rendering test" (it : @test.Test) {
   // Create the simplest possible SVG to test basic rendering
   let doc = @svg.new_svg(300.0, 200.0)
     .render_rectangle(0.0, 0.0, 300.0, 200.0, @color.white()) // White background
-    .render_circle(@vg.Point::Point(150.0, 100.0), 50.0, @color.red()) // Red circle in center
+    .render_circle(Point(150.0, 100.0), 50.0, @color.red()) // Red circle in center
     .render_rectangle(50.0, 50.0, 200.0, 100.0, @color.rgba(0.0, 0.0, 1.0, 0.5)) // Semi-transparent blue rect
-    .render_text(
-      "Hello SVG",
-      @vg.Point::Point(150.0, 100.0),
-      16.0,
-      @color.black(),
-    ) // Centered text
+    .render_text("Hello SVG", Point(150.0, 100.0), 16.0, @color.black()) // Centered text
   let svg_string = doc.to_string()
   it.write(svg_string)
   it.snapshot(filename="minimal_svg_test.svg")
@@ -551,7 +436,7 @@ test "minimal svg rendering test" (it : @test.Test) {
 test "simple rendering test" (it : @test.Test) {
   // Ultra-simple SVG that should definitely render
   let doc = @svg.new_svg(100.0, 100.0).render_circle(
-    @vg.Point::Point(50.0, 50.0),
+    Point(50.0, 50.0),
     30.0,
     @color.red(),
   )
@@ -565,7 +450,7 @@ test "html wrapped svg test" (it : @test.Test) {
   // Create an HTML file with embedded SVG for testing in browsers
   let doc = @svg.new_svg(400.0, 300.0)
     .render_rectangle(0.0, 0.0, 400.0, 300.0, @color.white())
-    .render_circle(@vg.Point::Point(200.0, 150.0), 50.0, @color.red())
+    .render_circle(Point(200.0, 150.0), 50.0, @color.red())
     .render_rectangle(
       100.0,
       100.0,
@@ -573,18 +458,8 @@ test "html wrapped svg test" (it : @test.Test) {
       100.0,
       @color.rgba(0.0, 1.0, 0.0, 0.5),
     )
-    .render_text(
-      "VG Library Test",
-      @vg.Point::Point(200.0, 50.0),
-      18.0,
-      @color.black(),
-    )
-    .render_line(
-      @vg.Point::Point(50.0, 250.0),
-      @vg.Point::Point(350.0, 250.0),
-      @color.blue(),
-      3.0,
-    )
+    .render_text("VG Library Test", Point(200.0, 50.0), 18.0, @color.black())
+    .render_line(Point(50.0, 250.0), Point(350.0, 250.0), @color.blue(), 3.0)
   let svg_string = doc.to_string()
   let html_content = "<!DOCTYPE html>\n<html>\n<head>\n" +
     "  <title>VG Library Test</title>\n" +

--- a/types.mbt
+++ b/types.mbt
@@ -38,19 +38,19 @@ pub enum Primitive {
 ///|
 /// Create a circle primitive
 pub fn primitive_circle(center : Point, radius : Double) -> Primitive {
-  Primitive::Circle(center, radius)
+  Circle(center, radius)
 }
 
 ///|
 /// Create a rectangle primitive
 pub fn primitive_rectangle(top_left : Point, bottom_right : Point) -> Primitive {
-  Primitive::Rectangle(top_left, bottom_right)
+  Rectangle(top_left, bottom_right)
 }
 
 ///|
 /// Create a path primitive
 pub fn primitive_path(path : Path) -> Primitive {
-  Primitive::Path(path)
+  Path(path)
 }
 
 ///|
@@ -60,7 +60,7 @@ pub fn primitive_text(
   position : Point,
   size : Double,
 ) -> Primitive {
-  Primitive::Text(text, position, size)
+  Text(text, position, size)
 }
 
 ///|
@@ -76,29 +76,29 @@ pub enum ImageOp {
 ///|
 /// Create a constant color image operation
 pub fn imageop_const(color : Color) -> ImageOp {
-  ImageOp::Const(color)
+  Const(color)
 }
 
 ///|
 /// Create a primitive image operation
 pub fn imageop_primitive(primitive : Primitive, color : Color) -> ImageOp {
-  ImageOp::Primitive(primitive, color)
+  Primitive(primitive, color)
 }
 
 ///|
 /// Create a transform image operation
 pub fn imageop_transform(transform : Transform, image : Image) -> ImageOp {
-  ImageOp::Transform(transform, image)
+  Transform(transform, image)
 }
 
 ///|
 /// Create a compose image operation
 pub fn imageop_compose(image1 : Image, image2 : Image) -> ImageOp {
-  ImageOp::Compose(image1, image2)
+  Compose(image1, image2)
 }
 
 ///|
 /// Create a cut image operation
 pub fn imageop_cut(image : Image, mask : Image) -> ImageOp {
-  ImageOp::Cut(image, mask)
+  Cut(image, mask)
 }

--- a/types_test.mbt
+++ b/types_test.mbt
@@ -42,13 +42,9 @@ test "Transform creation and equality" {
 ///|
 test "Path construction" {
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(1.0, 2.0))
-    .line_to(@vg.Point::Point(3.0, 4.0))
-    .curve_to(
-      @vg.Point::Point(1.0, 1.0),
-      @vg.Point::Point(2.0, 2.0),
-      @vg.Point::Point(3.0, 3.0),
-    )
+    .move_to(Point(1.0, 2.0))
+    .line_to(Point(3.0, 4.0))
+    .curve_to(Point(1.0, 1.0), Point(2.0, 2.0), Point(3.0, 3.0))
     .close_path()
   if path.0.length() != 4 {
     fail("Path should have 4 segments")
@@ -59,13 +55,9 @@ test "Path construction" {
 test "PathSegment variants" {
   // Test using path construction functions instead of direct enum construction
   let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(1.0, 2.0))
-    .line_to(@vg.Point::Point(3.0, 4.0))
-    .curve_to(
-      @vg.Point::Point(1.0, 1.0),
-      @vg.Point::Point(2.0, 2.0),
-      @vg.Point::Point(3.0, 3.0),
-    )
+    .move_to(Point(1.0, 2.0))
+    .line_to(Point(3.0, 4.0))
+    .curve_to(Point(1.0, 1.0), Point(2.0, 2.0), Point(3.0, 3.0))
     .close_path()
   if path.0.length() != 4 {
     fail("Path should have 4 segments")
@@ -129,9 +121,7 @@ test "Primitive constructors and equality" {
   }
 
   // Test path primitive
-  let path = @vg.Path::empty()
-    .move_to(@vg.Point::Point(1.0, 1.0))
-    .line_to(@vg.Point::Point(2.0, 2.0))
+  let path = @vg.Path::empty().move_to(Point(1.0, 1.0)).line_to(Point(2.0, 2.0))
   let path_prim = @vg.primitive_path(path)
   match path_prim {
     Path(p) => if p.0.length() != 2 { fail("Path should have 2 segments") }
@@ -233,12 +223,9 @@ test "Primitive and ImageOp integration" {
   let blue_color = @color.blue()
 
   // Create primitives
-  let circle = @vg.primitive_circle(@vg.Point::Point(50.0, 50.0), 25.0)
-  let rect = @vg.primitive_rectangle(
-    @vg.Point::Point(0.0, 0.0),
-    @vg.Point::Point(100.0, 20.0),
-  )
-  let text = @vg.primitive_text("Test", @vg.Point::Point(10.0, 80.0), 12.0)
+  let circle = @vg.primitive_circle(Point(50.0, 50.0), 25.0)
+  let rect = @vg.primitive_rectangle(Point(0.0, 0.0), Point(100.0, 20.0))
+  let text = @vg.primitive_text("Test", Point(10.0, 80.0), 12.0)
 
   // Create image operations
   let circle_op = @vg.imageop_primitive(circle, red_color)


### PR DESCRIPTION
Follow-up to the `Point::new` → `Point::Point` migration (#26).

## Summary

Enables the `unnecessary_annotation` lint (warning 73) in `moon.mod` and removes the qualifiers it flags — this is the payoff of the constructor rename: call sites can now read as bare `Point(...)`.

```diff
-warnings = "-unused_constructor-struct_never_constructed"
+warnings = "-unused_constructor-struct_never_constructed+unnecessary_annotation"
```

## What changed

- `@vg.Point::Point(...)` / `Point::Point(...)` → bare `Point(...)` wherever the expected type is known (array elements, function args, builder chains).
- A few pre-existing redundant qualifiers unrelated to Point: `@geometry.` in path-segment `match` arms, and `ImageOp::` / `Primitive::` enum-constructor prefixes.

Call sites with **no** inferable expected type (e.g. `let p = Point::Point(...)` in `image.mbt`) keep the qualifier — required to compile. The fix was applied from the lint's own reported locations (column-precise), then iterated to convergence (484 → 29 → 5 → 0).

## Validation

- `moon check` (with the new lint on): **0 errors, 0 warnings**
- `moon test`: **182 passed, 0 failed**
- `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)