### PR TITLE
Use `pub using` for facade re-exports so `@vg.T(...)` resolves

### DIFF
--- a/types.mbt
+++ b/types.mbt
@@ -3,24 +3,18 @@
 // Re-export geometry types
 
 ///|
-pub type Point = @geometry.Point
-
-///|
-pub type Box = @geometry.Box
-
-///|
-pub type Path = @geometry.Path
-
-///|
-pub type PathSegment = @geometry.PathSegment
-
-///|
-pub type Transform = @geometry.Transform
+pub using @geometry {
+  type Point,
+  type Box,
+  type Path,
+  type PathSegment,
+  type Transform,
+}
 
 // Re-export color type
 
 ///|
-pub type Color = @color.Color
+pub using @color {type Color}
 
 ///|
 /// An image is a function from points to colors


### PR DESCRIPTION
## Summary

Re-export the geometry/color types in the root `@vg` facade via **`pub using`** instead of `pub type X = @pkg.X` aliases.

```diff
-pub type Point = @geometry.Point
-pub type Box = @geometry.Box
-pub type Path = @geometry.Path
-pub type PathSegment = @geometry.PathSegment
-pub type Transform = @geometry.Transform
-pub type Color = @color.Color
+pub using @geometry {
+  type Point,
+  type Box,
+  type Path,
+  type PathSegment,
+  type Transform,
+}
+pub using @color { type Color }
```

## Why

The type-alias form re-exports only the *type*, so the constructor-call form `@vg.Point(...)` fails:

```
Value Point not found in package `vg`.
```

`pub using` additionally brings the type's associated constructor into the facade's value namespace, so all three forms now resolve consistently:

- `@vg.Point(1.0, 2.0)` ✅ (now works — even without an inferable expected type)
- `@vg.Point::Point(1.0, 2.0)` ✅
- `Point(1.0, 2.0)` ✅ (where the type is known)

The underlying type is unchanged: `@vg.Point` is still the same type as `@geometry.Point` (verified by assigning between them).

## Interface impact

**None.** `moon info` already renders both source forms identically as `pub using @geometry {type Point}`, so `pkg.generated.mbti` is unchanged — this is a source-level fix only.

## Context

This is the root cause behind moonbitlang/core#3695 (filed separately): the alias form and `pub using` are represented the same way in the generated interface, yet only `pub using` re-exports the constructor.

## Validation

- `moon check`: 0 errors, 0 warnings
- `moon test`: 182 passed, 0 failed
- `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)