### PR TITLE
Migrate PdfDocument::new to PdfDocument::PdfDocument

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -278,7 +278,7 @@ test "pdf generation examples" {
     .close_path()
 
   // Create a PDF document with fluent method chaining
-  let pdf_doc = @pdf.PdfDocument::new(210.0, 297.0) // A4 size
+  let pdf_doc = @pdf.PdfDocument(210.0, 297.0) // A4 size
     .render_circle(Point(105.0, 100.0), 30.0, @color.red())
     .render_rectangle(50.0, 150.0, 110.0, 50.0, @color.blue())
     .render_path(star_path, @color.gold())

--- a/oo_api_test.mbt
+++ b/oo_api_test.mbt
@@ -31,7 +31,7 @@ test "canvas oo-style api" (it : @test.Test) {
 ///|
 test "pdf oo-style api" (it : @test.Test) {
   // Demonstrate fluent OO-style API for PDF
-  let doc = @pdf.PdfDocument::new(300.0, 200.0)
+  let doc = @pdf.PdfDocument(300.0, 200.0)
     .render_rectangle(0.0, 0.0, 300.0, 200.0, @color.gray(0.95))
     .render_circle(Point(80.0, 100.0), 30.0, @color.red())
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green())
@@ -61,7 +61,7 @@ test "oo-style path with document integration" (it : @test.Test) {
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.white())
     .render_path(custom_path, @color.purple())
     .render_text("OO Path + Canvas", Point(125.0, 30.0), 14.0, @color.black())
-  let pdf_doc = @pdf.PdfDocument::new(250.0, 150.0)
+  let pdf_doc = @pdf.PdfDocument(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.white())
     .render_path(custom_path, @color.purple())
     .render_text("OO Path + PDF", Point(125.0, 30.0), 14.0, @color.black())

--- a/pdf/pdf.mbt
+++ b/pdf/pdf.mbt
@@ -11,7 +11,7 @@ pub struct PdfDocument {
 
 ///|
 /// Create a new PDF document
-pub fn PdfDocument::new(width : Double, height : Double) -> PdfDocument {
+pub fn PdfDocument::PdfDocument(width : Double, height : Double) -> PdfDocument {
   { width, height, objects: [], object_count: 0 }
 }
 

--- a/pdf/pkg.generated.mbti
+++ b/pdf/pkg.generated.mbti
@@ -18,7 +18,7 @@ pub struct PdfDocument {
   objects : Array[String]
   object_count : Int
 } derive(@debug.Debug)
-pub fn PdfDocument::new(Double, Double) -> Self
+pub fn PdfDocument::PdfDocument(Double, Double) -> Self
 pub fn PdfDocument::render_circle(Self, @geometry.Point, Double, @color.Color) -> Self
 pub fn PdfDocument::render_line(Self, @geometry.Point, @geometry.Point, @color.Color, Double) -> Self
 pub fn PdfDocument::render_path(Self, @geometry.Path, @color.Color) -> Self

--- a/renderer_test.mbt
+++ b/renderer_test.mbt
@@ -88,7 +88,7 @@ test "canvas path rendering" (it : @test.Test) {
 
 ///|
 test "pdf renderer basic shapes" (it : @test.Test) {
-  let doc = @pdf.PdfDocument::new(300.0, 200.0)
+  let doc = @pdf.PdfDocument(300.0, 200.0)
     .render_rectangle(10.0, 10.0, 280.0, 180.0, @color.gray(0.9)) // Background
     .render_circle(Point(80.0, 100.0), 30.0, @color.red()) // Red circle
     .render_rectangle(150.0, 70.0, 60.0, 60.0, @color.green()) // Green rectangle
@@ -130,7 +130,7 @@ test "pdf path rendering" (it : @test.Test) {
     .line_to(Point(60.0, 60.0))
     .line_to(Point(90.0, 60.0))
     .close_path()
-  let doc = @pdf.PdfDocument::new(200.0, 150.0)
+  let doc = @pdf.PdfDocument(200.0, 150.0)
     .render_rectangle(0.0, 0.0, 200.0, 150.0, @color.white())
     .render_path(star_path, @color.gold())
     .render_text("PDF Star", Point(100.0, 130.0), 12.0, @color.black())
@@ -158,7 +158,7 @@ test "renderer comparison showcase" (it : @test.Test) {
   let canvas_html = canvas_doc.to_html("Canvas Demo")
 
   // PDF version
-  let pdf_doc = @pdf.PdfDocument::new(250.0, 150.0)
+  let pdf_doc = @pdf.PdfDocument(250.0, 150.0)
     .render_rectangle(0.0, 0.0, 250.0, 150.0, @color.gray(0.95))
     .render_circle(Point(125.0, 75.0), 40.0, @color.red())
     .render_text("VG Demo", Point(125.0, 30.0), 16.0, @color.black())
@@ -244,7 +244,7 @@ test "complete feature showcase all renderers" (it : @test.Test) {
     )
 
   // PDF version
-  let pdf_doc = @pdf.PdfDocument::new(350.0, 200.0)
+  let pdf_doc = @pdf.PdfDocument(350.0, 200.0)
     .render_rectangle(0.0, 0.0, 350.0, 200.0, @color.white())
     .render_text(
       "PDF: Complete VG Features",


### PR DESCRIPTION
## Summary

Renames the PDF document constructor from `PdfDocument::new` to the idiomatic `PdfDocument::PdfDocument`, mirroring the `Point::new` → `Point::Point` migration (#26).

```diff
-pub fn PdfDocument::new(Double, Double) -> Self
+pub fn PdfDocument::PdfDocument(Double, Double) -> Self
```

Call sites use the short constructor form `@pdf.PdfDocument(...)` (resolves through the owning `@pdf` package), e.g.:

```diff
-let doc = @pdf.PdfDocument::new(300.0, 200.0)
+let doc = @pdf.PdfDocument(300.0, 200.0)
```

This was the only remaining `Type::new` constructor in `vg` itself (the rest surfaced by `moon ide doc '*::new'` are dependencies). No deprecated alias kept — no third-party users yet.

## Validation

- `moon check`: 0 errors, 0 warnings
- `moon test`: 182 passed, 0 failed
- `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)