### PR TITLE
Escape line terminators in canvas text output

### DIFF
--- a/canvas_fold.mbt
+++ b/canvas_fold.mbt
@@ -74,7 +74,8 @@ fn canvas_cmd(
 }
 
 ///|
-/// Escape a string for a single-quoted JavaScript literal.
+/// Escape a string for a single-quoted JavaScript literal, including line
+/// terminators (a raw newline in a JS string literal is a syntax error).
 fn js_text_escape(s : String) -> String {
   let parts : Array[String] = []
   for ch in s {
@@ -82,6 +83,9 @@ fn js_text_escape(s : String) -> String {
       match ch {
         '\\' => "\\\\"
         '\'' => "\\'"
+        '\n' => "\\n"
+        '\r' => "\\r"
+        '\t' => "\\t"
         _ => ch.to_string()
       },
     )

--- a/text_test.mbt
+++ b/text_test.mbt
@@ -18,3 +18,12 @@ test "text: draw-only, escaped, rendered by every backend" {
   assert_true(t.to_js(100.0, 100.0).contains("ctx.fillText('Hi <&>'"))
   assert_true(t.to_pdf(100.0, 100.0).contains(") Tj"))
 }
+
+///|
+test "text: newlines are escaped in canvas JS output" {
+  let t = @vg.Image::text("a\nb", 12.0, @color.black())
+  let js = t.to_js(100.0, 100.0)
+  // the literal must contain an escaped \n, not a raw line break
+  assert_true(js.contains("'a\\nb'"))
+  assert_true(!js.contains("'a\nb'"))
+}


### PR DESCRIPTION
Follow-up from the holistic codex review of the `Image`-AST re-architecture (#30).

## Issue (P3)

`js_text_escape` (canvas backend) escaped `\` and `'` but not line terminators. So `Image::text` content containing a newline produced a raw line break inside the single-quoted JS string of `ctx.fillText('...')`, making `to_js` output **syntactically invalid JavaScript**.

## Fix

Escape `\n`, `\r`, and `\t` as well. Multi-line text labels now emit valid JS. Added a regression test.

## Validation

- `moon check`: 0/0
- `moon test`: 213 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)