### PR TITLE
Release 0.2.0 — declarative Image AST + native vector backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## 0.2.0
+
+Re-architected `Image` from a `(Point) -> Color` function into a declarative
+**tree** (faithful to OCaml [Vg](https://github.com/dbuenzli/vg)), folded once
+into a backend-neutral draw list that each backend renders to **compact native
+vector output** — a circle is one `<path>`, not thousands of sampled `<rect>`s.
+
+### Breaking
+
+- `Image` is now an enum (`Primitive` / `Cut` / `Blend` / `Tr` / `Text`), no
+  longer a function wrapper. The old `primitive_*` / `imageop_*` constructors are
+  removed.
+- `compose` is **source-over**: `base.compose(overlay)` paints the overlay on
+  top (was additive blending).
+- `Image::line` is now a stroked outline with round caps (was a filled quad).
+
+### Added
+
+- **Native vector renderers**: `Image::to_svg`, `Image::to_pdf`, and
+  `Image::to_js` (HTML5 canvas) fold the AST into one element per shape.
+- `Image::eval` — the denotation (point → colour); the raster ground truth and
+  the fallback for procedural images.
+- Axial/radial gradients, non-zero and even-odd fills, stroke outlines
+  (`Area::Outline`), procedural images via a `Raster` primitive (`of_fn`,
+  `checkerboard`, `tile`, `conic_gradient`), and draw-only text (`Image::text`).
+- Per-format escaping (XML / PDF literal / JS string) in text output.
+
+### Fixed
+
+- The `render_image_to_svg` sampler used a width-based y-step, distorting
+  non-square canvases; it now uses the correct height-based step.
+
+## 0.1.4
+
+Initial published versions: core types, color/point/transform utilities, shape
+and path construction, and SVG/PDF/Canvas document builders.

--- a/canvas_fold.mbt
+++ b/canvas_fold.mbt
@@ -74,7 +74,8 @@ fn canvas_cmd(
 }
 
 ///|
-/// Escape a string for a single-quoted JavaScript literal.
+/// Escape a string for a single-quoted JavaScript literal, including line
+/// terminators (a raw newline in a JS string literal is a syntax error).
 fn js_text_escape(s : String) -> String {
   let parts : Array[String] = []
   for ch in s {
@@ -82,6 +83,9 @@ fn js_text_escape(s : String) -> String {
       match ch {
         '\\' => "\\\\"
         '\'' => "\\'"
+        '\n' => "\\n"
+        '\r' => "\\r"
+        '\t' => "\\t"
         _ => ch.to_string()
       },
     )

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/vg"
 
-version = "0.1.4"
+version = "0.2.0"
 
 readme = "README.md"
 

--- a/text_test.mbt
+++ b/text_test.mbt
@@ -18,3 +18,12 @@ test "text: draw-only, escaped, rendered by every backend" {
   assert_true(t.to_js(100.0, 100.0).contains("ctx.fillText('Hi <&>'"))
   assert_true(t.to_pdf(100.0, 100.0).contains(") Tj"))
 }
+
+///|
+test "text: newlines are escaped in canvas JS output" {
+  let t = @vg.Image::text("a\nb", 12.0, @color.black())
+  let js = t.to_js(100.0, 100.0)
+  // the literal must contain an escaped \n, not a raw line break
+  assert_true(js.contains("'a\\nb'"))
+  assert_true(!js.contains("'a\nb'"))
+}


### PR DESCRIPTION
Bumps `0.1.4` → `0.2.0` and adds `CHANGELOG.md`.

`0.2.0` ships the `Image`-AST re-architecture (PR #30): `Image` is now a declarative tree rendered to compact native vector output via `to_svg`/`to_pdf`/`to_js`, plus gradients, even-odd/outline fills, raster (procedural) images, and text. Breaking: `compose` is source-over and `Image::line` is a stroke. See the changelog for details.

- `moon check`: 0/0 · `moon test`: 213 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)