### PR TITLE
Functional-style simplifications (pattern match, comprehensions, spreads)

### DIFF
--- a/canvas/canvas.mbt
+++ b/canvas/canvas.mbt
@@ -75,12 +75,7 @@ pub fn CanvasDocument::add_command(
   self : CanvasDocument,
   command : String,
 ) -> CanvasDocument {
-  let new_commands = Array::new()
-  for cmd in self.commands {
-    new_commands.push(cmd)
-  }
-  new_commands.push(command)
-  { width: self.width, height: self.height, commands: new_commands }
+  { ..self, commands: [..self.commands, command] }
 }
 
 ///|

--- a/geometry/path.mbt
+++ b/geometry/path.mbt
@@ -9,23 +9,13 @@ pub fn Path::empty() -> Path {
 ///|
 /// Move to a point
 pub fn Path::move_to(self : Path, p : Point) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(MoveTo(p))
-  Path(new_path)
+  Path([..self.0, MoveTo(p)])
 }
 
 ///|
 /// Line to a point
 pub fn Path::line_to(self : Path, p : Point) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(LineTo(p))
-  Path(new_path)
+  Path([..self.0, LineTo(p)])
 }
 
 ///|
@@ -36,23 +26,13 @@ pub fn Path::curve_to(
   cp2 : Point,
   end : Point,
 ) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(CurveTo(cp1, cp2, end))
-  Path(new_path)
+  Path([..self.0, CurveTo(cp1, cp2, end)])
 }
 
 ///|
 /// Quadratic bezier curve to a point
 pub fn Path::qcurve_to(self : Path, cp : Point, end : Point) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(QCurveTo(cp, end))
-  Path(new_path)
+  Path([..self.0, QCurveTo(cp, end)])
 }
 
 ///|
@@ -66,23 +46,13 @@ pub fn Path::earc_to(
   sweep : Bool,
   end : Point,
 ) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(EArcTo(rx, ry, rotation, large_arc, sweep, end))
-  Path(new_path)
+  Path([..self.0, EArcTo(rx, ry, rotation, large_arc, sweep, end)])
 }
 
 ///|
 /// Close the path
 pub fn Path::close_path(self : Path) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
-  }
-  new_path.push(Close)
-  Path(new_path)
+  Path([..self.0, Close])
 }
 
 ///|
@@ -224,71 +194,44 @@ pub fn Path::bounds(self : Path) -> Box? {
 ///|
 /// Create a smooth cubic curve that connects smoothly to the previous segment
 pub fn Path::smooth_ccurve_to(self : Path, cp2 : Point, end : Point) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
+  // reflect the previous cubic control point for a smooth join
+  let cp1 = match self.0 {
+    [.., CurveTo(_, prev_cp2, prev_end)] =>
+      Point(2.0 * prev_end.x - prev_cp2.x, 2.0 * prev_end.y - prev_cp2.y)
+    _ => cp2
   }
-
-  // Calculate smooth control point based on previous segment
-  let cp1 = match self.0.length() {
-    0 => cp2 // No previous segment, use cp2
-    _ =>
-      match self.0[self.0.length() - 1] {
-        CurveTo(_, prev_cp2, prev_end) => {
-          // Reflect the previous control point
-          let reflected_x = 2.0 * prev_end.x - prev_cp2.x
-          let reflected_y = 2.0 * prev_end.y - prev_cp2.y
-          Point(reflected_x, reflected_y)
-        }
-        _ => cp2 // Not a curve, use cp2
-      }
-  }
-  new_path.push(CurveTo(cp1, cp2, end))
-  Path(new_path)
+  Path([..self.0, CurveTo(cp1, cp2, end)])
 }
 
 ///|
 /// Create a smooth quadratic curve that connects smoothly to the previous segment
 pub fn Path::smooth_qcurve_to(self : Path, end : Point) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    new_path.push(segment)
+  // reflect the previous quadratic control point for a smooth join
+  let cp = match self.0 {
+    [.., QCurveTo(prev_cp, prev_end)] =>
+      Point(2.0 * prev_end.x - prev_cp.x, 2.0 * prev_end.y - prev_cp.y)
+    _ => end
   }
-
-  // Calculate smooth control point based on previous segment
-  let cp = match self.0.length() {
-    0 => end // No previous segment, use end point
-    _ =>
-      match self.0[self.0.length() - 1] {
-        QCurveTo(prev_cp, prev_end) => {
-          // Reflect the previous control point
-          let reflected_x = 2.0 * prev_end.x - prev_cp.x
-          let reflected_y = 2.0 * prev_end.y - prev_cp.y
-          Point(reflected_x, reflected_y)
-        }
-        _ => end // Not a quadratic curve, use end point
-      }
-  }
-  new_path.push(QCurveTo(cp, end))
-  Path(new_path)
+  Path([..self.0, QCurveTo(cp, end)])
 }
 
 ///|
 /// Transform a path using a transformation matrix
 pub fn Path::transform(self : Path, t : Transform) -> Path {
-  let new_path = Array::new()
-  for segment in self.0 {
-    let transformed_segment = match segment {
-      MoveTo(p) => MoveTo(apply(t, p))
-      LineTo(p) => LineTo(apply(t, p))
-      CurveTo(cp1, cp2, end) =>
-        CurveTo(apply(t, cp1), apply(t, cp2), apply(t, end))
-      QCurveTo(cp, end) => QCurveTo(apply(t, cp), apply(t, end))
-      EArcTo(rx, ry, rotation, large_arc, sweep, end) =>
-        EArcTo(rx, ry, rotation, large_arc, sweep, apply(t, end))
-      Close => Close
-    }
-    new_path.push(transformed_segment)
-  }
-  Path(new_path)
+  Path(
+    [
+      for segment in self.0 => {
+        match segment {
+          MoveTo(p) => MoveTo(apply(t, p))
+          LineTo(p) => LineTo(apply(t, p))
+          CurveTo(cp1, cp2, end) =>
+            CurveTo(apply(t, cp1), apply(t, cp2), apply(t, end))
+          QCurveTo(cp, end) => QCurveTo(apply(t, cp), apply(t, end))
+          EArcTo(rx, ry, rotation, large_arc, sweep, end) =>
+            EArcTo(rx, ry, rotation, large_arc, sweep, apply(t, end))
+          Close => Close
+        }
+      }
+    ],
+  )
 }

--- a/pdf/pdf.mbt
+++ b/pdf/pdf.mbt
@@ -75,15 +75,9 @@ pub fn PdfDocument::add_raw(
 ///|
 /// Add an object to the PDF document (OO-style)
 fn PdfDocument::add_object(self : PdfDocument, obj : String) -> PdfDocument {
-  let new_objects = Array::new()
-  for o in self.objects {
-    new_objects.push(o)
-  }
-  new_objects.push(obj)
   {
-    width: self.width,
-    height: self.height,
-    objects: new_objects,
+    ..self,
+    objects: [..self.objects, obj],
     object_count: self.object_count + 1,
   }
 }

--- a/svg/svg.mbt
+++ b/svg/svg.mbt
@@ -45,26 +45,23 @@ fn point_to_svg(p : @geometry.Point) -> String {
 ///|
 /// Convert a path to SVG path data
 fn path_to_svg_data(path : @geometry.Path) -> String {
-  let mut data = ""
-  for segment in path.0 {
-    match segment {
-      MoveTo(p) => data = data + "M \{point_to_svg(p)} "
-      LineTo(p) => data = data + "L \{point_to_svg(p)} "
-      CurveTo(cp1, cp2, end) =>
-        data = data +
+  [
+    for segment in path.0 => {
+      match segment {
+        MoveTo(p) => "M \{point_to_svg(p)} "
+        LineTo(p) => "L \{point_to_svg(p)} "
+        CurveTo(cp1, cp2, end) =>
           "C \{point_to_svg(cp1)} \{point_to_svg(cp2)} \{point_to_svg(end)} "
-      QCurveTo(cp, end) =>
-        data = data + "Q \{point_to_svg(cp)} \{point_to_svg(end)} "
-      EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
-        let large_flag = if large_arc { "1" } else { "0" }
-        let sweep_flag = if sweep { "1" } else { "0" }
-        data = data +
+        QCurveTo(cp, end) => "Q \{point_to_svg(cp)} \{point_to_svg(end)} "
+        EArcTo(rx, ry, rotation, large_arc, sweep, end) => {
+          let large_flag = if large_arc { "1" } else { "0" }
+          let sweep_flag = if sweep { "1" } else { "0" }
           "A \{rx} \{ry} \{rotation} \{large_flag} \{sweep_flag} \{point_to_svg(end)} "
+        }
+        Close => "Z "
       }
-      Close => data = data + "Z "
     }
-  }
-  data
+  ].join("")
 }
 
 ///|
@@ -181,14 +178,7 @@ pub fn SvgDocument::render_polygon(
   if points.length() < 3 {
     self // Can't render polygon with less than 3 points
   } else {
-    let mut points_str = ""
-    for i = 0; i < points.length(); i = i + 1 {
-      let p = points[i]
-      points_str = points_str + "\{p.x},\{p.y}"
-      if i < points.length() - 1 {
-        points_str = points_str + " "
-      }
-    }
+    let points_str = [ for p in points => "\{p.x},\{p.y}" ].join(" ")
     let element =
       $|<polygon points="\{points_str}" fill="\{color_to_svg(color)}"/>
     self.add_element(element)


### PR DESCRIPTION
Project-level cleanup toward idiomatic functional MoonBit — **behaviour-preserving** (213 tests pass, all render snapshots byte-identical, public API unchanged).

## Changes

- **`geometry/path.mbt`**
  - Path builders (`move_to`/`line_to`/`curve_to`/…/`close_path`) collapse from copy-then-push loops to array spread: `Path([..self.0, MoveTo(p)])`.
  - `smooth_ccurve_to`/`smooth_qcurve_to` use **end-of-array patterns** (`match self.0 { [.., CurveTo(_, cp2, end)] => … }`) instead of `length()` + index.
  - `transform` uses an **array comprehension**.
- **`pdf/pdf.mbt`, `canvas/canvas.mbt`** — `add_object`/`add_command` use struct update + array spread (`{ ..self, objects: [..self.objects, obj] }`).
- **`svg/svg.mbt`** — `path_to_svg_data` and `render_polygon` use array comprehension + `join` (removes the last C-style `for i = 0; …` loop).

Applies the three requested idioms — pattern matching, list comprehensions, and functional loops — preferring functional style where performance is equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)