### PR TITLE
OO style: cut/blend as methods on Image

### DIFF
--- a/.claude/hooks/moon-gate.sh
+++ b/.claude/hooks/moon-gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Stop gate: when the turn tries to end, run `moon check`. If there are errors,
+# block the stop and feed the diagnostics back so the turn can't finish dirty.
+# This is the hard guarantee (level-triggered); the heartbeat is just awareness.
+
+export PATH="$HOME/.moon/bin:$PATH"
+
+input=$(cat)
+
+# Circuit breaker: if this stop is already the result of a prior block
+# (stop_hook_active), don't block again -- otherwise an unfixable error would
+# loop forever. One forced fix pass, then allow the stop.
+active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false')
+if [ "$active" = "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+raw=$(moon check --output-json 2>&1)
+errors=$(printf '%s\n' "$raw" | jq -rR 'fromjson? | .level? // empty' \
+  | grep -c '^error$' || true)
+
+# Clean -> allow the turn to end.
+if [ "$errors" -eq 0 ]; then
+  exit 0
+fi
+
+# Errors present -> block, with the error list as the reason.
+details=$(printf '%s\n' "$raw" \
+  | jq -rR 'fromjson? | select(.level? == "error") | "  \(.path // "?"): \(.message // "")"' \
+  | head -40)
+
+reason="moon check found ${errors} error(s) -- fix before ending the turn:
+${details}"
+
+jq -nc --arg r "$reason" '{decision:"block", reason:$r}'
+exit 0

--- a/.claude/hooks/moon-heartbeat.sh
+++ b/.claude/hooks/moon-heartbeat.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# PostToolUse heartbeat: after a MoonBit-relevant edit, run `moon check` and
+# report the error/warning counts back to the model as non-blocking context.
+# Always reports (even "0 error(s), 0 warning(s)") — stateless, no diffing.
+
+# Ensure moon is on PATH even when the hook runs with a minimal environment.
+export PATH="$HOME/.moon/bin:$PATH"
+
+# PostToolUse delivers the event as JSON on stdin; pull the edited file path.
+file=$(jq -r '.tool_input.file_path // empty')
+
+# Only edits that can change `moon check` results should trigger a check.
+# (matcher catches all file-edit tools; this narrows to MoonBit files.)
+case "$file" in
+  *.mbt | *.mbt.md | */moon.mod | */moon.pkg) ;; # relevant -> run check
+  *) exit 0 ;;                                    # anything else -> silent skip
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+# moon check --output-json emits one JSON diagnostic per line, each with "level".
+levels=$(moon check --output-json 2>&1 | jq -rR 'fromjson? | .level? // empty')
+errors=$(printf '%s\n' "$levels" | grep -c '^error$' || true)
+warnings=$(printf '%s\n' "$levels" | grep -c '^warning$' || true)
+
+jq -nc --arg ctx "moon check: ${errors} error(s), ${warnings} warning(s)" \
+  '{hookSpecificOutput:{hookEventName:"PostToolUse",additionalContext:$ctx}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/moon-heartbeat.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/moon-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -102,15 +102,12 @@ centre is offset up-left, giving a lit-from-above look.
 ///|
 test "demo: glossy spheres" (it : @test.Test) {
   fn sphere(cx : Double, cy : Double, r : Double, hue : Double) -> @vg.Image {
-    @vg.cut(
-      @vg.Path::circle(Point(cx, cy), r),
-      @vg.Image::radial_gradient(
-        @color.white(),
-        @color.hsv(hue, 0.9, 0.6),
-        Point(cx - r * 0.35, cy - r * 0.35),
-        r * 1.45,
-      ),
-    )
+    @vg.Image::radial_gradient(
+      @color.white(),
+      @color.hsv(hue, 0.9, 0.6),
+      Point(cx - r * 0.35, cy - r * 0.35),
+      r * 1.45,
+    ).cut(@vg.Path::circle(Point(cx, cy), r))
   }
 
   let bg = @vg.Image::linear_gradient(
@@ -139,15 +136,12 @@ centre by a transform.
 ```mbt check
 ///|
 test "demo: gradient mandala" (it : @test.Test) {
-  let petal = @vg.cut(
-    @vg.Path::ellipse(Point(0.0, -70.0), 20.0, 58.0),
-    @vg.Image::linear_gradient(
-      @color.hsv(285.0, 0.85, 1.0),
-      @color.hsv(185.0, 0.9, 1.0),
-      Point(0.0, -128.0),
-      Point(0.0, -12.0),
-    ),
-  )
+  let petal = @vg.Image::linear_gradient(
+    @color.hsv(285.0, 0.85, 1.0),
+    @color.hsv(185.0, 0.9, 1.0),
+    Point(0.0, -128.0),
+    Point(0.0, -12.0),
+  ).cut(@vg.Path::ellipse(Point(0.0, -70.0), 20.0, 58.0))
   let two_pi = 2.0 * 3.14159265358979
   let mut art = @vg.Image::const_color(@color.rgb(0.07, 0.05, 0.12))
   for i in 0..<16 {

--- a/canvas_fold_test.mbt
+++ b/canvas_fold_test.mbt
@@ -11,15 +11,12 @@ test "canvas fold: a circle produces a path and fill" {
 
 ///|
 test "canvas fold: gradients are native (createLinearGradient)" {
-  let img = @vg.cut(
-    @vg.Path::rect(-10.0, -10.0, 20.0, 20.0),
-    @vg.Image::linear_gradient(
-      @color.red(),
-      @color.blue(),
-      Point(-10.0, 0.0),
-      Point(10.0, 0.0),
-    ),
-  )
+  let img = @vg.Image::linear_gradient(
+    @color.red(),
+    @color.blue(),
+    Point(-10.0, 0.0),
+    Point(10.0, 0.0),
+  ).cut(@vg.Path::rect(-10.0, -10.0, 20.0, 20.0))
   let js = img.to_js(50.0, 50.0)
   assert_true(js.contains("ctx.createLinearGradient("))
   assert_true(js.contains(".addColorStop("))
@@ -27,9 +24,8 @@ test "canvas fold: gradients are native (createLinearGradient)" {
 
 ///|
 test "canvas fold: clip uses save/clip/restore" {
-  let img = @vg.cut(
+  let img = @vg.Image::circle(@color.red(), 5.0).cut(
     @vg.Path::circle(Point(0.0, 0.0), 10.0),
-    @vg.Image::circle(@color.red(), 5.0),
   )
   let js = img.to_js(50.0, 50.0)
   assert_true(js.contains("ctx.save();"))
@@ -39,9 +35,8 @@ test "canvas fold: clip uses save/clip/restore" {
 
 ///|
 test "canvas fold: even-odd fill rule" {
-  let img = @vg.cut(
+  let img = @vg.Image::const_color(@color.blue()).cut(
     @vg.Path::rect(-10.0, -10.0, 20.0, 20.0),
-    @vg.Image::const_color(@color.blue()),
     area=Aeo,
   )
   assert_true(img.to_js(50.0, 50.0).contains("ctx.fill('evenodd');"))
@@ -53,7 +48,7 @@ test "elliptical arc renders consistently across backends" {
     .move_to(Point(-20.0, 0.0))
     .earc_to(20.0, 20.0, 0.0, false, true, Point(20.0, 0.0))
     .close_path()
-  let img = @vg.cut(arc, @vg.Image::const_color(@color.red()))
+  let img = @vg.Image::const_color(@color.red()).cut(arc)
   // SVG keeps the native arc; canvas/eval flatten it (not a chord)
   assert_true(img.to_svg(60.0, 60.0).contains("A 20 20"))
   assert_true(img.to_js(60.0, 60.0).contains("ctx.lineTo"))

--- a/image.mbt
+++ b/image.mbt
@@ -18,10 +18,16 @@ pub fn Image::empty() -> Image {
 }
 
 ///|
-/// Cut image `img` to the inside of `path` (default non-zero winding). Outside
-/// the path the result is transparent.
+/// Clip `self` to the inside of `path` (default non-zero winding). Outside the
+/// path the result is transparent.
+pub fn Image::cut(self : Image, path : Path, area? : Area = Anz) -> Image {
+  Cut(area, path, self)
+}
+
+///|
+#deprecated("Use `image.cut(path)` instead")
 pub fn cut(path : Path, img : Image, area? : Area = Anz) -> Image {
-  Cut(area, path, img)
+  img.cut(path, area~)
 }
 
 ///|
@@ -31,14 +37,16 @@ pub fn Image::over(self : Image, bottom : Image) -> Image {
 }
 
 ///|
-/// Blend `top` with `bottom` using an explicit operator and optional top alpha.
-pub fn blend(
-  top : Image,
+/// Blend `self` (the top layer) with `bottom` using an explicit operator and an
+/// optional top alpha.
+#as_free_fn(blend, deprecated="Use `top.blend(bottom)` instead")
+pub fn Image::blend(
+  self : Image,
   bottom : Image,
   op? : Blender = Over,
   alpha? : Double,
 ) -> Image {
-  Blend(op, alpha, top, bottom)
+  Blend(op, alpha, self, bottom)
 }
 
 // ----- transforms -----

--- a/image_test.mbt
+++ b/image_test.mbt
@@ -101,9 +101,8 @@ test "image composition is source-over" {
 
 ///|
 test "path cut" {
-  let img = @vg.cut(
+  let img = @vg.Image::const_color(@color.red()).cut(
     @vg.Path::circle(Point(0.0, 0.0), 3.0),
-    @vg.Image::const_color(@color.red()),
   )
   // inside the cut path, then outside
   debug_inspect(
@@ -219,8 +218,7 @@ test "path boundary samples count as inside" {
 ///|
 test "plus blend respects top opacity" {
   // a fully-transparent top adds nothing under Plus -> the black bottom shows
-  let faded = @vg.blend(
-    @vg.Image::const_color(@color.red()),
+  let faded = @vg.Image::const_color(@color.red()).blend(
     @vg.Image::const_color(@color.black()),
     op=Plus,
     alpha=0.0,

--- a/pdf_fold_test.mbt
+++ b/pdf_fold_test.mbt
@@ -20,9 +20,8 @@ test "pdf fold: rectangle path is y-flipped" {
 
 ///|
 test "pdf fold: even-odd fill uses f*" {
-  let img = @vg.cut(
+  let img = @vg.Image::const_color(@color.blue()).cut(
     @vg.Path::rect(-10.0, -10.0, 20.0, 20.0),
-    @vg.Image::const_color(@color.blue()),
     area=Aeo,
   )
   assert_true(img.to_pdf(50.0, 50.0).contains("f*"))
@@ -30,9 +29,8 @@ test "pdf fold: even-odd fill uses f*" {
 
 ///|
 test "pdf fold: clip emits W n" {
-  let img = @vg.cut(
+  let img = @vg.Image::circle(@color.red(), 5.0).cut(
     @vg.Path::circle(Point(0.0, 0.0), 10.0),
-    @vg.Image::circle(@color.red(), 5.0),
   )
   assert_true(img.to_pdf(50.0, 50.0).contains("W n"))
 }

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -8,8 +8,7 @@ import {
 }
 
 // Values
-pub fn blend(Image, Image, op? : Blender, alpha? : Double) -> Image
-
+#deprecated
 pub fn cut(@geometry.Path, Image, area? : Area) -> Image
 
 // Errors
@@ -50,11 +49,14 @@ pub(all) enum Image {
   Text(String, Double, @color.Color)
 }
 pub fn Image::axial_gradient(@color.Color, @color.Color, @geometry.Point, @geometry.Point) -> Self
+#as_free_fn(blend, deprecated)
+pub fn Image::blend(Self, Self, op? : Blender, alpha? : Double) -> Self
 pub fn Image::checkerboard(@color.Color, @color.Color, Double) -> Self
 pub fn Image::circle(@color.Color, Double) -> Self
 pub fn Image::compose(Self, Self) -> Self
 pub fn Image::conic_gradient(@color.Color, @color.Color, @geometry.Point, Double) -> Self
 pub fn Image::const_color(@color.Color) -> Self
+pub fn Image::cut(Self, @geometry.Path, area? : Area) -> Self
 pub fn Image::ellipse(@color.Color, Double, Double) -> Self
 pub fn Image::empty() -> Self
 pub fn Image::eval(Self, @geometry.Point) -> @color.Color

--- a/svg_fold_test.mbt
+++ b/svg_fold_test.mbt
@@ -25,15 +25,12 @@ test "vector fold: rectangle SVG markup" {
 
 ///|
 test "vector fold: gradient becomes a <defs> entry referenced by fill" {
-  let g = @vg.cut(
-    @vg.Path::rect(-50.0, -50.0, 100.0, 100.0),
-    @vg.Image::linear_gradient(
-      @color.red(),
-      @color.blue(),
-      Point(-50.0, 0.0),
-      Point(50.0, 0.0),
-    ),
-  )
+  let g = @vg.Image::linear_gradient(
+    @color.red(),
+    @color.blue(),
+    Point(-50.0, 0.0),
+    Point(50.0, 0.0),
+  ).cut(@vg.Path::rect(-50.0, -50.0, 100.0, 100.0))
   let svg = g.to_svg(100.0, 100.0)
   assert_true(svg.contains("<linearGradient"))
   assert_true(svg.contains("fill=\"url(#grad0)\""))


### PR DESCRIPTION
Converts the two remaining public free functions to methods, for a uniform, discoverable API. The image is the receiver ("clip/blend *this* image"); both still return new immutable values.

```
cut(path, img, area?)         ->  img.cut(path, area?)
blend(top, bottom, op?, ...)  ->  top.blend(bottom, op?, ...)
```

Deprecated free-function shims keep old code compiling:
- `cut` via `#deprecated` (preserves the original path-first arg order)
- `blend` via `#as_free_fn`

All internal callers (tests + README demos) updated to the method form. Output is **byte-identical** — 216 tests pass, snapshots unchanged, `moon check` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)