### PR TITLE
Release 0.3.0: cut/blend methods + vg/turtle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.3.0
+
+OO-style API polish plus a new generative-art package.
+
+### Added
+
+- **`vg/turtle`** — an optional turtle-graphics + L-system package. `LSystem`
+  rewrites an axiom by per-symbol rules; `render` walks the result as turtle
+  commands (`F`/`f` forward, `+`/`-` turn, `[`/`]` branch) into one stroked
+  `@vg.Image`. Ships tested Koch-snowflake and branching-plant demos.
+
+### Changed
+
+- `cut` and `blend` are now **methods on `Image`** (`img.cut(path)`,
+  `top.blend(bottom)`) for a uniform, discoverable API. The free functions
+  remain as deprecated shims.
+- `geometry`'s `Path` and `PathSegment` are now `pub(all)`, so downstream
+  packages can build a segment array directly (the turtle backend uses this to
+  keep `render` linear rather than quadratic).
+
 ## 0.2.0
 
 Re-architected `Image` from a `(Point) -> Color` function into a declarative

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/vg"
 
-version = "0.2.0"
+version = "0.3.0"
 
 readme = "README.md"
 


### PR DESCRIPTION
Bumps `0.2.0 → 0.3.0` and records the two features merged since 0.2.0.

### Added
- **`vg/turtle`** (#36) — optional turtle-graphics + L-system package; `LSystem` rewriting + `render` to a stroked `@vg.Image`, with tested Koch-snowflake and branching-plant demos.

### Changed
- `cut`/`blend` are now **methods on `Image`** (#35); deprecated free-fn shims kept.
- `geometry`'s `Path`/`PathSegment` are `pub(all)`, so downstream packages can build segment arrays directly (keeps turtle `render` linear).

`moon check` 0/0 · 219 tests pass. Codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)